### PR TITLE
Fixing POST request issues.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Removed ZLib dependency, using built in node implementation - this solves an installation issue
+- POST requests are now being proxied correctly - this allows `<form method="post">` and calls to `.post()` routes which weren't previously working in development mode unless the request body was empty
 
 ## 0.4.0
 

--- a/features/editing/routes.feature
+++ b/features/editing/routes.feature
@@ -2,19 +2,19 @@
 Feature: Routes
 
   @no-variant
-  Scenario: Custom get route
-    Given I append the file "app/routes.js" with contents "router.get('/hello/:name', function (req, res) {res.send('<h1>hello ' + req.params.name + '</h1>')})"
-    When I visit "/hello/world"
-    Then the main heading should be updated to "hello world"
-    When I visit "/hello/you"
-    Then the main heading should be updated to "hello you"
-
-  @no-variant
   @auto-reload
-  Scenario: Custom get route
+  Scenario: Custom get route - auto reload
     Given I visit "/example2"
     Then the main heading should be updated to "Page not found"
     When I append the file "app/routes.js" with contents "router.get('/example2', function (req, res) {res.send('<h1>hello example 2 - part 1</h1>')})"
     Then the main heading should be updated to "hello example 2 - part 1"
     When I replace "hello example 2 - part 1" with "hello example 2 - part 2" in the file "app/routes.js"
     Then the main heading should be updated to "hello example 2 - part 2"
+
+  @no-variant
+  Scenario: Custom get route
+    Given I append the file "app/routes.js" with contents "router.get('/hello/:name', function (req, res) {res.send('<h1>hello ' + req.params.name + '</h1>')})"
+    When I visit "/hello/world"
+    Then the main heading should be updated to "hello world"
+    When I visit "/hello/you"
+    Then the main heading should be updated to "hello you"

--- a/features/fixtures/html/form-with-get-action.html
+++ b/features/fixtures/html/form-with-get-action.html
@@ -1,0 +1,11 @@
+<!doctype HTML>
+<html lang="en">
+<head><title>Basic form example</title></head>
+<body>
+<form action="?" method="get">
+  <label for="example">Example</label>
+  <input type="text" value="hello world" name="example" id="example">
+  <button type="submit">Submit</button>
+</form>
+</body>
+</html>

--- a/features/fixtures/html/form-with-post-action.html
+++ b/features/fixtures/html/form-with-post-action.html
@@ -1,0 +1,11 @@
+<!doctype HTML>
+<html lang="en">
+<head><title>Basic form example</title></head>
+<body>
+<form action="?" method="post">
+  <label for="example">Example</label>
+  <input type="text" value="hello world" name="example" id="example">
+  <button type="submit">Submit</button>
+</form>
+</body>
+</html>

--- a/features/fixtures/nunjucks/form-receiver.njk
+++ b/features/fixtures/nunjucks/form-receiver.njk
@@ -1,0 +1,7 @@
+<!doctype HTML>
+<html>
+<head><title>Basic form example</title></head>
+<body>
+<h1>You entered: {{ data.example }}</h1>
+</body>
+</html>

--- a/features/step-definitions/hooks.steps.js
+++ b/features/step-definitions/hooks.steps.js
@@ -51,7 +51,6 @@ if (process.env.DELAY_BETWEEN_TESTS) {
 After(kitStartTimeout, async function (scenario) {
   const isFailure = scenario.result.status === 'FAILED'
   const scenarioName = scenario.pickle.name
-  this.kit?.reset()
   process.stdout.write(colors.bold(' ' + (isFailure ? colors.red('✘ ' + scenarioName) : colors.green('✓ ' + scenarioName))))
   console.log('')
   if (isFailure) {
@@ -71,6 +70,7 @@ After(kitStartTimeout, async function (scenario) {
     }
     process.exitCode = 10
   }
+  await this.kit?.reset()
   this.browser?.openUrl('about:blank')
   if (process.env.DELAY_BETWEEN_TESTS) {
     await sleep(parseInt(process.env.DELAY_BETWEEN_TESTS, 10))

--- a/features/user-content/forms.feature
+++ b/features/user-content/forms.feature
@@ -1,0 +1,25 @@
+Feature: Forms
+
+  @no-variant
+  Scenario: Form with GET action
+    Given I create a file "app/views/form.html" based on the fixture file "html/form-with-get-action.html"
+    And I create a file "app/views/form-receiver.html" based on the fixture file "nunjucks/form-receiver.njk"
+    And I visit "/form-receiver"
+    And the main heading should be updated to "You entered:"
+    When I visit "/form"
+    And I enter "Hey, this is the test" into the "example" field
+    And I submit the form
+    And I visit "/form-receiver"
+    Then the main heading should be updated to "You entered: Hey, this is the test"
+
+  @no-variant
+  Scenario: Form with POST action
+    Given I create a file "app/views/form.html" based on the fixture file "html/form-with-post-action.html"
+    And I create a file "app/views/form-receiver.html" based on the fixture file "nunjucks/form-receiver.njk"
+    And I visit "/form-receiver"
+    And the main heading should be updated to "You entered:"
+    When I visit "/form"
+    And I enter "This is from a post" into the "example" field
+    And I submit the form
+    And I visit "/form-receiver"
+    Then the main heading should be updated to "You entered: This is from a post"

--- a/lib/dev-server/manage-prototype/manage-prototype-runner.js
+++ b/lib/dev-server/manage-prototype/manage-prototype-runner.js
@@ -3,7 +3,6 @@ process.on('disconnect', () => {
 })
 
 const express = require('express')
-const bodyParser = require('body-parser')
 const nunjucks = require('nunjucks')
 const app = express()
 const eventTypes = require('../dev-server-event-types')
@@ -93,8 +92,6 @@ nunjucks.configure(templatesPath, {
 })
 
 app.set('view engine', 'njk')
-
-app.use(bodyParser.urlencoded({ extended: true }))
 
 ;(async () => {
   await refresherServer(app, config)

--- a/lib/dev-server/manage-prototype/routes/management-pages/inherited-manage-prototype-routes.js
+++ b/lib/dev-server/manage-prototype/routes/management-pages/inherited-manage-prototype-routes.js
@@ -1,5 +1,7 @@
 // We're moving away form this approach, please add new work to lib/manage-prototype, see settings as an example
 
+const bodyParser = require('body-parser')
+
 const {
   csrfProtection,
   getCsrfTokenHandler,
@@ -18,6 +20,8 @@ const {
 } = require('./inherited-manage-prototype-handlers')
 const { contextPath } = require('../../utils')
 
+const bpMiddleware = bodyParser.urlencoded({ extended: true })
+
 module.exports = {
   inheritedRoutes: (router) => {
     router.get('/csrf-token', getCsrfTokenHandler)
@@ -28,14 +32,14 @@ module.exports = {
 
     router.get('/templates/install', getTemplatesInstallHandler)
 
-    router.post('/templates/install', postTemplatesInstallHandler)
+    router.post('/templates/install', [bpMiddleware], postTemplatesInstallHandler)
 
     router.get('/templates/post-install', getTemplatesPostInstallHandler)
 
     router.get('/plugins', (req, res) => {
       res.redirect(req.originalUrl.split('?')[0] + '/installed')
     })
-    router.post('/plugins', postPluginsHandler)
+    router.post('/plugins', [bpMiddleware], postPluginsHandler)
     router.get('/plugins/installed', getPluginsHandler)
     router.get('/plugins/discover', getPluginsHandler)
     router.get('/plugins/lookup', getPluginLookupHandler)
@@ -45,12 +49,12 @@ module.exports = {
     })
 
     router.get('/plugin/:packageRef', getPluginDetailsHandler)
-    router.post('/plugin', postPluginDetailsHandler)
+    router.post('/plugin', [bpMiddleware], postPluginDetailsHandler)
     router.get('/plugin/:packageRef/:mode', getPluginsModeHandler)
-    router.post('/plugin/:packageRef/:mode', csrfProtection, runPluginMode)
+    router.post('/plugin/:packageRef/:mode', [bpMiddleware], csrfProtection, runPluginMode)
 
     // // Be aware that changing this path for monitoring the status of a plugin will affect the
     // // kit update process as the browser request and server route would be out of sync.
-    router.post('/plugins/:mode', legacyUpdateStatusCompatibilityHandler)
+    router.post('/plugins/:mode', [bpMiddleware], legacyUpdateStatusCompatibilityHandler)
   }
 }

--- a/lib/dev-server/manage-prototype/routes/management-pages/settings.js
+++ b/lib/dev-server/manage-prototype/routes/management-pages/settings.js
@@ -1,4 +1,5 @@
 const { getManagementView, contextPath, getPageNavLinks } = require('../../utils')
+const bodyParser = require('body-parser')
 const { readJSON, writeJSON } = require('fs-extra')
 const path = require('path')
 const { projectDir } = require('../../../../utils/paths')
@@ -7,6 +8,8 @@ const defaultValue = '__default__'
 const events = require('../../../dev-server-events')
 const eventTypes = require('../../../dev-server-event-types')
 const { getSettingsForUI, preparePackageNameForDisplay } = require('../../../../plugins/plugins')
+
+const bpMiddleware = bodyParser.urlencoded({ extended: true })
 
 function getSideNavLinks (path) {
   const coreSettingsPages = [
@@ -188,7 +191,7 @@ function setupUrlToHandleFields (router, url, fields) {
     const model = await getModel(req, fields)
     res.render(getSettingsView(), model)
   })
-  router.post(url, async (req, res) => {
+  router.post(url, [bpMiddleware], async (req, res) => {
     const toastQueryString = await saveConfigUpdates(req, fields)
     res.redirect(req.originalUrl.split('?')[0] + '?' + toastQueryString)
   })

--- a/lib/dev-server/manage-prototype/routes/proxyRemainingRequests.js
+++ b/lib/dev-server/manage-prototype/routes/proxyRemainingRequests.js
@@ -144,7 +144,7 @@ async function proxyRequest (req, sendResponse, sendError, config) {
   let statusMessage
   let headers
   const chunks = []
-  http.request(options, response => {
+  const proxyRequest = http.request(options, response => {
     response
       .on('end', async () => {
         const resultBuffer = Buffer.concat(chunks)
@@ -169,7 +169,8 @@ async function proxyRequest (req, sendResponse, sendError, config) {
       sendError(err)
       console.error('Error from HTTP response: ', err.message || err)
     })
-    .end()
+
+  req.pipe(proxyRequest)
 }
 
 // From Jetbrains AI Assistant

--- a/lib/dev-server/watch/server.js
+++ b/lib/dev-server/watch/server.js
@@ -6,6 +6,10 @@ const prototypeNunjucks = require('./prototypeNunjucks')
 const prototypeStyles = require('./prototypeStyles')
 const prototypeConfig = require('./prototypeConfig')
 const { debounce, monitorEventLoop } = require('../../utils')
+const events = require('../dev-server-events')
+const eventTypes = require('../dev-server-event-types')
+
+monitorEventLoop('watcher')
 
 ;(async () => {
   await Promise.all([
@@ -17,6 +21,5 @@ const { debounce, monitorEventLoop } = require('../../utils')
     prototypeStyles.setup(debounce),
     prototypeConfig.setup(debounce)
   ])
+  events.emitExternal(eventTypes.RELOAD_PAGE)
 })()
-
-monitorEventLoop('watcher')


### PR DESCRIPTION
Previously forms with `action="get"` would work but forms with `action="post"` would just hang when being used in development mode.  It was caused by an issue with the proxy that allows us to do things like auto-reloading, this issues is now resolved.