### PR TITLE
Fixed repeated-reload issue.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+- Fixed an issue causing repeated reloads.
+
 ## 0.6.0
 
 ### Experimental Features

--- a/lib/dev-server/manage-prototype/assets/scripts/reloader-client.js
+++ b/lib/dev-server/manage-prototype/assets/scripts/reloader-client.js
@@ -1,7 +1,11 @@
 (() => {
-  // eslint-disable-next-line
-  const lastReload = (window.nowPrototypeItGOVUK && window.nowPrototypeItGOVUK.lastReload) || __DATE__
-  const urlPath = window.location.pathname
+  let lastReload
+  try {
+    // eslint-disable-next-line
+    lastReload = __DATE__
+  } catch (e) {
+    lastReload = Date.now()
+  }
 
   const scrollTo = window.localStorage.getItem('nowprotoypeit-scroll-after-reload')
   if (scrollTo) {
@@ -17,7 +21,7 @@
         response.json().then(json => {
           if (json.shouldReload) {
             window.localStorage.setItem('nowprotoypeit-scroll-after-reload', window.scrollY)
-            window.location.href = urlPath
+            window.location.reload()
           } else {
             setTimeout(checkForReload, json.nextCheckInMilliseconds || 1000)
           }

--- a/lib/dev-server/manage-prototype/routes/proxyRemainingRequests.js
+++ b/lib/dev-server/manage-prototype/routes/proxyRemainingRequests.js
@@ -35,8 +35,6 @@ module.exports = {
     app.use(async (req, res) => {
       const fullRequestTimer = startPerformanceTimer()
       const requestTimestamp = Date.now()
-      const reloaderHtml = await getReloaderHtml()
-
       async function sendResponse ({
         response,
         resultBuffer,
@@ -44,6 +42,9 @@ module.exports = {
         statusMessage,
         headers
       }) {
+        headers['Cache-Control'] = 'no-cache, no-store, must-revalidate'
+        headers.Pragma = 'no-cache'
+        headers.Expires = '0'
         if (statusCode === 404 && req.originalUrl.startsWith('/favicon.ico')) {
           try {
             res.send(await fsp.readFile(path.join(getPathToDesignSystemAssets(), 'icons', 'favicon.ico')))
@@ -98,6 +99,8 @@ module.exports = {
         sendHeaders()
         if (userConfig.getConfig().autoReloadPages && headers['content-type']?.startsWith('text/html')) {
           const userHtml = resultBuffer.toString()
+
+          const reloaderHtml = await getReloaderHtml()
           const responseBody = userHtml.includes('<head') ? insertAfterTag(userHtml, 'head', reloaderHtml) : userHtml + reloaderHtml
           res.send(responseBody)
           endPerformanceTimer('proxyRemainingRequests (text/html with refresher)', fullRequestTimer)


### PR DESCRIPTION
The issue was caused by browser caching which means that the reload doesn't pick up the changes and another refresh is attempted.  Changing the caching resolves this issue and is a pretty reasonable given the transitive nature of page renders when prototyping.