### PR TITLE
Fixing in-browser update in Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Fixes
+
+- Fixing in-browser update on Windows, adding a version endpoint to allow future tests to know which kit version is 
+  running.
+
 ## 0.9.2
 
 ### Fixes

--- a/bin/cli
+++ b/bin/cli
@@ -363,10 +363,10 @@ async function runInit () {
 }
 
 async function runDev () {
+  let currentlyRunningKit
   console.log(`Now Prototype It Kit ${kitVersion}`)
   console.log('')
   console.log('starting...')
-  const closeEvent = 'KIT_PROCESS_CLOSED'
 
   process.on('SIGTERM', (info) => {
     stop().then(() => {
@@ -377,22 +377,30 @@ async function runDev () {
   let scriptProcess
 
   function start (entryPoint = undefined) {
-    scriptProcess = fork(path.join(kitRoot, entryPoint), {
+    scriptProcess = fork(path.join(projectDir, 'node_modules', 'nowprototypeit', entryPoint), {
       cwd: projectDir,
       env: { ...process.env },
       stdio: 'inherit',
       eventEmitter: events,
       passOnEvents: [eventTypes.FULL_KIT_RESTART, eventTypes.FULL_KIT_STOP],
-      logAllEvents: true,
-      closeEvent
+      logAllEvents: true
     })
+    currentlyRunningKit = scriptProcess
   }
 
   function stop () {
+    if (!currentlyRunningKit) {
+      return Promise.resolve()
+    }
+
     return new Promise(resolve => {
-      events.once(closeEvent, () => {
-        resolve()
-      })
+      currentlyRunningKit.finishedPromise
+        .catch((err) => { console.log(err ? '' : '') })
+        .then(() => {
+          currentlyRunningKit = undefined
+          resolve()
+        })
+
       scriptProcess.close()
     })
   }

--- a/lib/dev-server/manage-prototype/routes/management-pages/basicPages.js
+++ b/lib/dev-server/manage-prototype/routes/management-pages/basicPages.js
@@ -1,10 +1,13 @@
 const http = require('node:http')
+const fsp = require('node:fs').promises
+const path = require('node:path')
 
 const { getPageNavLinks, awaitOrResolveWithDefault } = require('../../utils')
 const { requestHttpsJson } = require('../../../../utils/requestHttps')
 const kitVersion = require('../../../../../package.json').version
 const { getConfig } = require('../../../../config')
 const { findPagesInUsersKit } = require('../../../../utils')
+const { projectDir } = require('../../../../utils/paths')
 
 const url = `${getConfig().npiApiBaseUrl}/v1/messages/npi/${encodeURIComponent(kitVersion)}`
 const messagesPromise = requestHttpsJson(url, {}).catch(() => null)
@@ -63,6 +66,20 @@ module.exports = {
         ...getModel('Clear session data', req),
         returnUrl: req.query.returnUrl
       })
+    })
+
+    router.get('/version', async (req, res) => {
+      const resultParts = ['<!DOCTYPE html><html><head><title>Kit Version</title></head><body>']
+      resultParts.push(`<p id="kit-version">${kitVersion}</p>`)
+      resultParts.push('<p id="npi-dependency">')
+      await fsp.readFile(path.join(projectDir, 'package.json'), 'utf8').then((packageJson) => {
+        const deps = JSON.parse(packageJson).dependencies
+        resultParts.push(deps.nowprototypeit)
+      }).catch(() => {
+        resultParts.push('Error reading package.json')
+      })
+      resultParts.push('</p></body></html>')
+      res.send(resultParts.join(''))
     })
   }
 }


### PR DESCRIPTION
Also fixed updating from a local version and added endpoint for testing which version of the kit is running to allow future tests to make sure the restart has happened.