### PR TITLE
Early test of update test part two

### DIFF
--- a/features/plugins/update-kit.feature
+++ b/features/plugins/update-kit.feature
@@ -6,11 +6,7 @@ Feature: Handle kit install
     When I install the "0.9.2" version of the kit from NPM
     Then I should be using version "0.9.2" of the kit from NPM
 
-#  ---
-#  This can be run experimentally after version 0.9.4 is released.  If those tests go smoothly then they should be
-#  usable when the package version during the test is above 0.9.4.
-#  ---
-#  @kit-update-from-0.9.4
-#  Scenario: Upgrading to the version being tested
-#    When I install the version of the kit being tested
-#    Then I should be using version of the kit being tested
+  @kit-update-from-0.9.4
+  Scenario: Upgrading to the version being tested
+    When I install the version of the kit being tested
+    Then I should be using version of the kit being tested

--- a/features/step-definitions/plugins.steps.js
+++ b/features/step-definitions/plugins.steps.js
@@ -129,13 +129,11 @@ When('I install the {string} version of the kit from NPM', pluginActionTimeout, 
 })
 When('I install the version of the kit being tested', pluginActionTimeout, async function () {
   const dependencyBeingTested = getDependencyBeingTested()
-  console.log('dependency dir (when)', dependencyBeingTested)
   await visitPluginPageAndRunAction(this.browser, `fs:${dependencyBeingTested}`, 'action-install', true)
 })
 
 Then('I should be using version of the kit being tested', pluginActionTimeout, async function () {
   const dependencyBeingTested = getDependencyBeingTested()
-  console.log('dependency dir (then)', dependencyBeingTested)
   const packageJson = await fsp.readFile(path.join(this.kit.dir, 'package.json'), 'utf8')
   const parsedPackageJson = JSON.parse(packageJson)
 

--- a/features/step-definitions/utils.js
+++ b/features/step-definitions/utils.js
@@ -197,7 +197,7 @@ async function startKit (config = {}) {
     cleanup: async () => {
       const shouldCleanUpDir = config.shouldCleanupDir ?? !config.dir
       if (shouldCleanUpDir) {
-        await fsp.rm(dir, { recursive: true })
+        await fsp.rm(dir, { recursive: true, force: true })
       }
       if (config.afterCleanup) {
         config.afterCleanup()

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nowprototypeit",
   "description": "A fully configurable, high-fidelity prototype kit",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "engines": {
     "node": "^16.x || ^18.x || >= 20.x"
   },


### PR DESCRIPTION
This involves faking package version to allow testing the update to the version being tested. This shouldn't be merged but if the test is successful the package JSON will be in this state after the next release allowing the test to then be merged.

The reason for faking this test is that if it needs changes on the previously released version I'd rather know before releasing the next version.

Context of the test approach is here https://github.com/nowprototypeit/nowprototypeit/pull/44#issuecomment-2412606866