### PR TITLE
Upgrading to a specific sass version to avoid deprecation warnings.

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -25,7 +25,7 @@
         "monaco-editor": "^0.48.0",
         "nunjucks": "^3.2.4",
         "portscanner": "^2.2.0",
-        "sass": "^1.69.5",
+        "sass": "1.77.6",
         "tar": "^6.2.1",
         "tar-stream": "^3.1.6"
       },
@@ -9256,9 +9256,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sass": {
-      "version": "1.70.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.70.0.tgz",
-      "integrity": "sha512-uUxNQ3zAHeAx5nRFskBnrWzDUJrrvpCPD5FNAoRvTi0WwremlheES3tg+56PaVtCs5QDRX5CBLxxKMDJMEa1WQ==",
+      "version": "1.77.6",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.6.tgz",
+      "integrity": "sha512-ByXE1oLD79GVq9Ht1PeHWCPMPB8XHpBuz1r85oByKHjZY6qV6rWnQovQzXJXuQ/XyE1Oj3iPk3lo28uzaRA2/Q==",
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -17820,9 +17820,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sass": {
-      "version": "1.70.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.70.0.tgz",
-      "integrity": "sha512-uUxNQ3zAHeAx5nRFskBnrWzDUJrrvpCPD5FNAoRvTi0WwremlheES3tg+56PaVtCs5QDRX5CBLxxKMDJMEa1WQ==",
+      "version": "1.77.6",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.6.tgz",
+      "integrity": "sha512-ByXE1oLD79GVq9Ht1PeHWCPMPB8XHpBuz1r85oByKHjZY6qV6rWnQovQzXJXuQ/XyE1Oj3iPk3lo28uzaRA2/Q==",
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "monaco-editor": "^0.48.0",
     "nunjucks": "^3.2.4",
     "portscanner": "^2.2.0",
-    "sass": "^1.69.5",
+    "sass": "1.77.6",
     "tar": "^6.2.1",
     "tar-stream": "^3.1.6"
   },


### PR DESCRIPTION
Before this the console was full of logs like:

```
Deprecation Warning: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.

More info and automated migrator: https://sass-lang.com/d/import

  ╷
8 │ @import ".tmp/sass/user/application";
  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ╵
    ../../nowprototypeit/nowprototypeit/lib/assets/sass/prototype.scss 8:9  root stylesheet
```

I've tried moving over to the new format and at first glance it doesn't seem to be compatible with our approach and it may be that plugins need to make changes in-sync with our changes.  The plan is to do one or more of the following:

a) Continue looking for an exact match of the functionality that we can start using without consequence to plugin developers
b) Start moving plugins over to the new approach with appropriate flags in the `nowprototypeit.config.json` file so we know how to handle them when we include them
c) Look for a new SASS interpreter
d) Continue with this version of SASS while it is free from known vulnerabilities
e) Add this to the plugin validator so that plugin authors are encouraged to make the required changes

While that's going on in the background I don't see why the average prototype kit user should be seeing these warnings, them getting used to ignoring warnings can lead to bigger problems in the longer term.