### PR TITLE
Added hosting tab as an experimental feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+- Added the hosting tab to Manage Prototype
+
 ### Improvements
 
 - More improvements to the hosting pages.

--- a/lib/config.js
+++ b/lib/config.js
@@ -98,8 +98,8 @@ function getConfig (config, swallowError = true) {
   overrideOrDefault('showPluginDowngradeButtons', 'SHOW_PLUGIN_DOWNGRADE_BUTTONS', asBoolean, false)
   overrideOrDefault('showPluginDebugInfo', 'SHOW_PLUGIN_DEBUG_INFO', asBoolean, false)
   overrideOrDefault('turnOffFunctionCaching', 'TURN_OFF_FUNCTION_CACHING', asBoolean, false)
+  overrideOrDefault('hostingEnabled', 'NPI_HOSTING_ENABLED', asBoolean, false)
 
-  config.hostingEnabled = process.env.NPI_HOSTING_ENABLED === 'true'
   config.nowPrototypeItAPIBaseUrl = process.env.NPI_API_BASE_URL ?? 'https://api.nowprototype.it'
 
   config.passwords = (config.passwordKeys.split(','))

--- a/lib/dev-server/manage-prototype/routes/management-pages/hosting.js
+++ b/lib/dev-server/manage-prototype/routes/management-pages/hosting.js
@@ -155,7 +155,8 @@ module.exports = {
         headerSubNavItems: getPageNavLinks(req),
         errorSplash: lookupErrorSplash(req.query['error-splash'], req.query.error),
         currentUrl: req.originalUrl,
-        redirectUrl: originalUrl
+        redirectUrl: originalUrl,
+        loggedOutMessage: hostingConfig.loggedOutMessage
       })
     })
     function getLoginType (req) {

--- a/lib/dev-server/manage-prototype/routes/management-pages/settings.js
+++ b/lib/dev-server/manage-prototype/routes/management-pages/settings.js
@@ -277,6 +277,13 @@ const setupSettingsRoutes = (router) => {
       description: 'Allows you to use .html for HTML files without nunjucks processing, allows you to use .md for Markdown files. Extremely experimental, implementation is very likely to change.'
     },
     {
+      key: 'hostingEnabled',
+      type: 'bool',
+      name: 'Show the hosting tab in Manage Prototype',
+      stage: 1,
+      description: 'We will be adding the hosting tab for everyone but at the time of writing we\'re testing it with the first round of users.'
+    },
+    {
       key: 'editInBrowser',
       type: 'bool',
       name: 'Edit your prototype in the browser',

--- a/lib/dev-server/manage-prototype/utils.js
+++ b/lib/dev-server/manage-prototype/utils.js
@@ -26,10 +26,6 @@ const getManagementLinks = () => {
     {
       name: 'Settings',
       url: contextPath + '/settings'
-    },
-    {
-      name: 'Clear session data',
-      url: contextPath + '/clear-data'
     }
   ]
   const extraLinks = []
@@ -40,10 +36,13 @@ const getManagementLinks = () => {
     })
   }
   extraLinks.push({
+    name: 'Clear session data',
+    url: contextPath + '/clear-data'
+  })
+  extraLinks.push({
     name: 'Back to your prototype',
     url: '/'
-  }
-  )
+  })
   return standardLinks.concat(extraLinks)
 }
 

--- a/lib/dev-server/manage-prototype/views/hosting-logged-out.njk
+++ b/lib/dev-server/manage-prototype/views/hosting-logged-out.njk
@@ -22,8 +22,11 @@
 
   <h1>Prototype Hosting from Now Prototype It</h1>
 
-  <p>To start hosing you'll need to log in to your nowprototype.it account.</p>
+  <p>To start hosting you'll need to log in to your nowprototype.it account.</p>
 
+  {% if loggedOutMessage %}
+    <p>{{ loggedOutMessage | safe }}</p>
+  {% endif %}
   {% if errorSplash %}
     {{ nowPrototypeItError({
       titleText: errorSplash.title,

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8,7 +8,7 @@
       "name": "nowprototypeit",
       "version": "0.9.5",
       "dependencies": {
-        "@nowprototypeit/design-system": "^1.0.6",
+        "@nowprototypeit/design-system": "^1.0.7",
         "body-parser": "^1.20.2",
         "chokidar": "^3.6.0",
         "cookie-parser": "^1.4.6",
@@ -54,12 +54,6 @@
       "engines": {
         "node": "^16.x || ^18.x || >= 20.x"
       }
-    },
-    "../design-system": {
-      "name": "@nowprototypeit/design-system",
-      "version": "1.0.6",
-      "extraneous": true,
-      "license": "MIT"
     },
     "../nowprototypeit-design-system": {
       "version": "1.0.4",
@@ -1721,9 +1715,9 @@
       }
     },
     "node_modules/@nowprototypeit/design-system": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@nowprototypeit/design-system/-/design-system-1.0.6.tgz",
-      "integrity": "sha512-OqUF1N9cKzDW/7nG3hgUfMmvptoSzYMTwysX25Ax1GH2uc+XiKZRAN0C8+HMbQ0y3xd4P2qLXd5moTxwXM9dPw=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@nowprototypeit/design-system/-/design-system-1.0.7.tgz",
+      "integrity": "sha512-9lElrbIMGqeUUnfDJQSl7e9pjukI7wxytJyuzxlFt7qaNMPbFXWozu87Hcg8UTHbQ0gHuKm0GBTWE0NumRxhPA=="
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -12266,9 +12260,9 @@
       }
     },
     "@nowprototypeit/design-system": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@nowprototypeit/design-system/-/design-system-1.0.6.tgz",
-      "integrity": "sha512-OqUF1N9cKzDW/7nG3hgUfMmvptoSzYMTwysX25Ax1GH2uc+XiKZRAN0C8+HMbQ0y3xd4P2qLXd5moTxwXM9dPw=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@nowprototypeit/design-system/-/design-system-1.0.7.tgz",
+      "integrity": "sha512-9lElrbIMGqeUUnfDJQSl7e9pjukI7wxytJyuzxlFt7qaNMPbFXWozu87Hcg8UTHbQ0gHuKm0GBTWE0NumRxhPA=="
     },
     "@pkgjs/parseargs": {
       "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "test": "npm run lint && npm run test:unit && npm run test:browser:all"
   },
   "dependencies": {
-    "@nowprototypeit/design-system": "^1.0.6",
+    "@nowprototypeit/design-system": "^1.0.7",
     "body-parser": "^1.20.2",
     "chokidar": "^3.6.0",
     "cookie-parser": "^1.4.6",


### PR DESCRIPTION
We've been busy working on a [prototype hosting platform](https://nowprototype.it/hosting).  We're now adding the hosting tab to the kit.  We're adding it as an experiment so that users who are testing can turn it on within the kit.

If you'd like to be in the Alpha Phase testing for hosting please reach out to support@nowprototype.it, if not feel free to continue using the kit as you were before.

(also using the latest design system)