### PR TITLE
Improved plugin validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Improvements
+
+ - Improved the plugin validator, partially caught up with the new features in the plugin system
+ - Included the licence in the package.json so it can be seen more clearly in the npm registry (we were already using the MIT licence, just not displaying it in NPM)
+
 ## 0.11.0
 
 ### New Features

--- a/lib/plugins/plugin-validator.js
+++ b/lib/plugins/plugin-validator.js
@@ -19,7 +19,9 @@ const knownKeys = [
   'stylesheets',
   'templates',
   'pluginDependencies',
-  'meta'
+  'meta',
+  'relatedPlugins',
+  'settings'
 ]
 
 function checkPathExists (executionPath, pathToValidate, key) {
@@ -167,6 +169,23 @@ function validateMeta (meta) {
   validateMetaUrls(meta.urls)
 }
 
+function validateRelatedPlugins (relatedPlugins) {
+  if (typeof relatedPlugins !== 'object') {
+    errors.push('The relatedPlugins must be an object if entered')
+    return
+  }
+
+  if (!Array.isArray(relatedPlugins.fromNpm)) {
+    errors.push('Currently the only supported option in relatedPlugins is "fromNpm", which must be present and must be an array')
+    return
+  }
+
+  const keys = Object.keys(relatedPlugins)
+  if (keys.length > 1) {
+    errors.push('Currently the only supported option in relatedPlugins is "fromNpm", keys used were [' + keys.join(', ') + ']')
+  }
+}
+
 function validatePluginDependency (key, configEntry) {
   if (typeof configEntry === 'string') {
     return
@@ -188,6 +207,10 @@ function validatePluginDependency (key, configEntry) {
   if (Object.keys(configEntry).includes('maxVersion') && typeof maxVersion !== 'string' && typeof maxVersion !== 'undefined') {
     errors.push(`In section ${key}, the maxVersion '${maxVersion}' should be a valid version if entered`)
   }
+}
+
+function validateSettings (settings) {
+  // todo
 }
 
 function checkSass (executionPath, pluginConfig) {
@@ -226,6 +249,10 @@ function validateConfigurationValues (pluginConfig, executionPath) {
       try {
         if (key === 'meta') {
           validateMeta(configEntry)
+        } else if (key === 'relatedPlugins') {
+          validateRelatedPlugins(configEntry)
+        } else if (key === 'settings') {
+          validateSettings(configEntry)
         } else if (key === 'pluginDependencies') {
           validatePluginDependency(key, configEntry)
         } else if (key === 'scripts' && configEntry.path !== undefined && configEntry.path[0] === '/') {

--- a/lib/plugins/plugin-validator.spec.js
+++ b/lib/plugins/plugin-validator.spec.js
@@ -16,7 +16,9 @@ const expectedTopLevelKeysText = `
  - stylesheets
  - templates
  - pluginDependencies
- - meta`
+ - meta
+ - relatedPlugins
+ - settings`
 
 describe('plugin-validator', () => {
   let testScope = {}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "nowprototypeit",
   "description": "A fully configurable, high-fidelity prototype kit",
+  "license": "MIT",
   "version": "0.11.0",
   "engines": {
     "node": "^16.x || ^18.x || >= 20.x"


### PR DESCRIPTION
The plugin system has grown and the validator hasn't grown with it.  This is part of the process of catching up.

I've also included the MIT license in the package.json - this is not a change of license, we just weren't displaying it in the NPM UI.