### PR TITLE
Removing service name as core config (as it's plugin-specific)

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -77,7 +77,6 @@ function getConfig (config, swallowError = true) {
   config.isTest = getNodeEnv() === 'test' || process.env.IS_INTEGRATION_TEST === 'true'
 
   // basic
-  overrideOrDefault('serviceName', 'SERVICE_NAME', asString, 'Now Prototype It - GOV.UK Prototype Kit')
   overrideOrDefault('useAutoStoreData', 'USE_AUTO_STORE_DATA', asBoolean, true)
   overrideOrDefault('port', 'PORT', asNumber, 3000)
   overrideOrDefault('showPrereleases', 'SHOW_PRERELEASES', asBoolean, false)

--- a/lib/config.test.js
+++ b/lib/config.test.js
@@ -17,7 +17,6 @@ const originalEnvironmentVariables = process.env
 describe('config', () => {
   const defaultConfig = Object.freeze({
     port: 3000,
-    serviceName: 'Now Prototype It - GOV.UK Prototype Kit',
     useAuth: true,
     useHttps: true,
     useAutoStoreData: true,
@@ -78,37 +77,25 @@ describe('config', () => {
     expect(config.getConfig()).toStrictEqual(defaultConfig)
   })
 
-  it('allows the user to set the service name', () => {
-    testScope.configJs = {
-      serviceName: 'My Test Service'
-    }
-
-    expect(config.getConfig()).toStrictEqual(mergeWithDefaults({
-      serviceName: 'My Test Service'
-    }))
-  })
-
   it('allows the user to set autoReloadPages', () => {
     testScope.configJs = {
-      serviceName: 'My Test Service',
       autoReloadPages: false
     }
 
     expect(config.getConfig()).toStrictEqual(mergeWithDefaults({
-      serviceName: 'My Test Service',
       autoReloadPages: false
     }))
   })
 
   it('allows the user to set some values in config and others in environment variables', () => {
     testScope.configJs = {
-      serviceName: 'Another Test Service'
+      useAuth: true
     }
 
     process.env.AUTO_RELOAD_PAGES = 'false'
 
     expect(config.getConfig()).toStrictEqual(mergeWithDefaults({
-      serviceName: 'Another Test Service',
+      useAuth: true,
       autoReloadPages: false
     }))
   })

--- a/lib/dev-server/manage-prototype/routes/management-pages/settings.js
+++ b/lib/dev-server/manage-prototype/routes/management-pages/settings.js
@@ -139,9 +139,6 @@ async function saveConfigUpdates (req, fields) {
       if (hasChanged(fieldConfig, 'port', value)) {
         toastQueryString += '&changedPort=true'
       }
-      if (hasChanged(fieldConfig, 'serviceName', value)) {
-        events.emitExternal(eventTypes.KIT_RESTART)
-      }
       if (fieldConfig.type === 'bool') {
         if (value === 'true') {
           setValue(key, true, fieldConfig.context)
@@ -183,6 +180,7 @@ async function saveConfigUpdates (req, fields) {
     delete configObj['plugin-specific']
   }
   await writeConfig(configObj)
+  events.emitExternal(eventTypes.KIT_RESTART)
   return toastQueryString
 }
 

--- a/server.js
+++ b/server.js
@@ -46,7 +46,6 @@ app.locals.managePrototypeUrl = '/manage-prototype'
 app.locals.useAutoStoreData = config.useAutoStoreData
 app.locals.releaseVersion = 'v' + releaseVersion
 app.locals.isRunningInPrototypeKit = true
-app.locals.serviceName = config.serviceName
 // pluginConfig sets up variables used to add the scripts and stylesheets to each page.
 app.locals.pluginConfig = plugins.getAppConfig({
   scripts: utils.prototypeAppScripts


### PR DESCRIPTION
This will still be available as usual for plugins like `govuk-frontend-adaptor` which [define it in their config](https://github.com/nowprototypeit/adaptors/blob/main/govuk-frontend-adaptor/now-prototype-it.config.json#L94-L106).