### PR TITLE
Showing an error when the session-data-defaults.js file has a syntax error.

### DIFF
--- a/features/editing/errors.feature
+++ b/features/editing/errors.feature
@@ -30,3 +30,19 @@ Feature: Error handling
     And the error details should contain additional information starting with "The following directories were checked:"
     And the source code should start at line 1
     And the source code should end at line 6
+
+  @no-variant
+  @serverside-js
+  Scenario: Server-side JavaScript error, broken session data defaults
+    Given I create a file "app/data/session-data-defaults.js" based on the fixture file "serverside-js/broken-session-data-defaults_js"
+    When I visit "/"
+    Then the main heading should be updated to "Your prototype failed to start"
+    Then the page title should read "Error running your prototype – Now Prototype It"
+    Then I should see an error page
+    And the error details should contain "File path:" "app/views/broken-session-data-defaults.js"
+    And the error details should contain "Line number:" "2"
+    And the error details should contain "Error type:" "SyntaxError"
+    And the error details should contain "Error message:" "Unexpected string"
+    And the source code should start at line 1
+    And the source code should end at line 4
+    And only line 2 should be highlighted

--- a/features/fixtures/serverside-js/broken-session-data-defaults_js
+++ b/features/fixtures/serverside-js/broken-session-data-defaults_js
@@ -1,0 +1,3 @@
+module.exports = {
+  'broken'
+}

--- a/features/step-definitions/error.steps.js
+++ b/features/step-definitions/error.steps.js
@@ -1,6 +1,7 @@
 const { Then } = require('@cucumber/cucumber')
 const { expect, standardTimeout } = require('./utils')
 const { By } = require('selenium-webdriver')
+const path = require('path')
 
 Then('I should see an error page', standardTimeout, async function () {
   let classArray
@@ -59,6 +60,10 @@ Then('the error details should contain additional information starting with {str
   ;(await expect(additionalDetails.split('\n')[0].trim())).to.eq(startOfAdditionalInfo)
 })
 
+function standardiseWindowsFilenamesForTestAssertion (output, index, text) {
+  return output[index] === 'File path:' ? text.split(path.sep).join('/') : text
+}
+
 Then('the error details should contain {string} {string}', standardTimeout, async function (name, value) {
   const info = await getErrorDetailElements(this.browser)
 
@@ -70,7 +75,8 @@ Then('the error details should contain {string} {string}', standardTimeout, asyn
       output.push(text)
     } else if (tagName === 'dd') {
       const index = output.length - 1
-      output[index] = output[index] + separator + text
+      const preparedText = standardiseWindowsFilenamesForTestAssertion(output, index, text)
+      output[index] = output[index] + separator + preparedText
     }
   })
 

--- a/lib/session.js
+++ b/lib/session.js
@@ -1,5 +1,6 @@
 // core dependencies
 const path = require('path')
+const fs = require('fs')
 
 // npm dependencies
 const session = require('express-session')
@@ -84,15 +85,18 @@ function storeData (input, data) {
 
 // Get session default data from file
 
-let sessionDataDefaults
+function loadSessionDataDefaults () {
+  const sessionDataDefaultsFile = path.join(projectDir, 'app', 'data', 'session-data-defaults.js')
 
-const sessionDataDefaultsFile = path.join(projectDir, 'app', 'data', 'session-data-defaults.js')
-
-try {
-  sessionDataDefaults = require(sessionDataDefaultsFile)
-} catch (e) {
-  sessionDataDefaults = {}
+  if (fs.existsSync(sessionDataDefaultsFile)) {
+    return require(sessionDataDefaultsFile)
+  } else {
+    return {}
+  }
 }
+
+const sessionDataDefaults = loadSessionDataDefaults()
+
 // Middleware - store any data sent in session, and pass it to all views
 
 function autoStoreData (req, res, next) {

--- a/lib/utils/errorModel.js
+++ b/lib/utils/errorModel.js
@@ -1,7 +1,6 @@
-const path = require('path')
 const fsp = require('fs').promises
 
-const { projectDir, packageDir } = require('./paths')
+const paths = require('./paths')
 const { getKnownPlugins } = require('../plugins/plugins')
 
 async function tryParsingModuleNotFoundError (stderrLinesReversed) {
@@ -23,7 +22,6 @@ async function tryParsingModuleNotFoundError (stderrLinesReversed) {
   const errorMessageBeforeCheck = errorLines.join('\n')
   const errorMessage = errorMessageBeforeCheck.startsWith('Error: ') ? errorMessageBeforeCheck.substring(7) : errorMessageBeforeCheck
   const errorMessageParts = errorMessage.split('\'')
-  console.log(errorMessageParts)
   const output = {
     filePath: stackLines[0].split(' ')[1],
     message: errorMessage,
@@ -41,7 +39,22 @@ async function tryParsingModuleNotFoundError (stderrLinesReversed) {
   return output
 }
 
-async function tryParsingNodeError (stderrLinesReversed) {
+function getFileDescriptionFromLine (currentLineContents) {
+  if (currentLineContents.includes(paths.projectDir) || currentLineContents.includes(paths.packageDir)) {
+    const fileDescriptionParts = currentLineContents.trim().split(':')
+    const windowsDriveNameMaximumLength = 1
+    if (fileDescriptionParts[0].length <= windowsDriveNameMaximumLength) {
+      fileDescriptionParts.unshift(fileDescriptionParts.shift() + ':' + fileDescriptionParts.shift())
+    }
+    return {
+      filePath: fileDescriptionParts[0],
+      line: fileDescriptionParts[1],
+      column: fileDescriptionParts[2]
+    }
+  }
+}
+
+async function tryParsingNodeError (stderrLinesReversed, fullError) {
   let currentLine = 0
   const lines = stderrLinesReversed.filter(x => x !== '')
   const endNotReached = () => lines.length > currentLine
@@ -50,7 +63,6 @@ async function tryParsingNodeError (stderrLinesReversed) {
     currentLine += 1
   }
 
-  const startOfError = currentLine
   const stackTraceLines = []
   while (endNotReached() && lines[currentLine].trim().startsWith('at')) {
     stackTraceLines.push(lines[currentLine++])
@@ -60,17 +72,15 @@ async function tryParsingNodeError (stderrLinesReversed) {
   if (!messageLine) {
     return
   }
-  const [type, message] = messageLine.split(':').length === 1 ? [undefined, messageLine] : messageLine.split(':')
+  const splitMessageLine = messageLine.split(':').map(x => x.trim())
+  const [type, message] = splitMessageLine.length === 1 ? [undefined, messageLine] : splitMessageLine
   let fileDescriptionParts
-
-  while (endNotReached()) {
-    if (lines[currentLine].includes(projectDir) || lines[currentLine].includes(packageDir)) {
-      fileDescriptionParts = lines[currentLine].trim().split(':')
-    }
+  while (endNotReached() && fileDescriptionParts === undefined) {
+    const currentLineContents = lines[currentLine]
+    fileDescriptionParts = getFileDescriptionFromLine(currentLineContents)
     currentLine++
   }
-
-  const [filePath, line, column] = fileDescriptionParts
+  const { filePath, line, column } = fileDescriptionParts || {}
 
   return {
     filePath,
@@ -79,7 +89,7 @@ async function tryParsingNodeError (stderrLinesReversed) {
     message,
     type,
     stackTrace: stackTraceLines.reverse().join('\n'),
-    fullError: lines.slice(startOfError).reverse().join('\n'),
+    fullError,
     parsedBy: 'tryParsingNodeError'
   }
 }
@@ -131,8 +141,8 @@ async function getSourceCodeLines (result) {
 }
 
 function prepareFilePath (absolutePath) {
-  if (absolutePath?.startsWith(projectDir)) {
-    return path.relative(projectDir, absolutePath)
+  if (absolutePath?.startsWith(paths.projectDir)) {
+    return absolutePath.replace(paths.projectDir, '')
   }
   return absolutePath
 }
@@ -156,7 +166,7 @@ async function getErrorModelFromStderr (stderr, requestTimestamp) {
   const stderrLinesReversed = stderr.split('\n').reverse()
   const parsersToTry = [tryParsingModuleNotFoundError, tryParsingNodeError]
   while (parsersToTry.length > 0) {
-    const result = await parsersToTry.shift()(stderrLinesReversed)
+    const result = await parsersToTry.shift()(stderrLinesReversed, stderr)
     if (result) {
       return await addStandardModel({ ...result, stderr }, true)
     }
@@ -210,9 +220,7 @@ async function getErrorModelFromErrObj (errObj, requestTimestamp) {
   if (errObj.isNunjucksError || errObj.name === 'Template render error') {
     return await parseNunjucksError(errObj, requestTimestamp)
   }
-  const newVar = await addStandardModel({ fullError: errObj.stack, ...errObj }, false, requestTimestamp)
-  console.log('new var', newVar)
-  return newVar
+  return await addStandardModel({ fullError: errObj.stack, ...errObj }, false, requestTimestamp)
 }
 
 async function getErrorModelFromException (err, lastReloadTimestamp) {

--- a/lib/utils/errorModel.spec.js
+++ b/lib/utils/errorModel.spec.js
@@ -1,0 +1,88 @@
+const { getErrorModelFromStderr } = require('./errorModel')
+
+const ubuntuStackTrace = `    at internalCompileFunction (node:internal/vm:128:18)
+    at wrapSafe (node:internal/modules/cjs/loader:1280:20)
+    at Module._compile (node:internal/modules/cjs/loader:1332:27)
+    at Module._extensions..js (node:internal/modules/cjs/loader:1427:10)
+    at Module.load (node:internal/modules/cjs/loader:1206:32)
+    at Module._load (node:internal/modules/cjs/loader:1022:12)
+    at Module.require (node:internal/modules/cjs/loader:1231:19)
+    at require (node:internal/modules/helpers:179:18)
+    at loadSessionDataDefaults (/home/natalie/projects/nowprototypeit/nowprototypeit/lib/session.js:92:12)
+    at Object.<anonymous> (/home/natalie/projects/nowprototypeit/nowprototypeit/lib/session.js:98:29)`
+
+const ubuntuExample = `/home/natalie/projects/prototype-kits/now-prototype-it-companion/app/data/session-data-defaults.js:2
+  'broken'
+  ^^^^^^^^
+
+SyntaxError: Unexpected string
+${ubuntuStackTrace}
+    
+    Node v20.12.0
+`
+
+const windowsStackTrace = `    at internalCompileFunction (node:internal/vm:73:18)
+    at wrapSafe (node:internal/modules/cjs/loader:1176:20)
+    at Module._compile (node:internal/modules/cjs/loader:1218:27)
+    at Module._extensions..js (node:internal/modules/cjs/loader:1308:10)
+    at Module.load (node:internal/modules/cjs/loader:1117:32)
+    at Module._load (node:internal/modules/cjs/loader:958:12)
+    at Module.require (node:internal/modules/cjs/loader:1141:19)
+    at require (node:internal/modules/cjs/helpers:110:18)
+    at loadSessionDataDefaults (C:\\Users\\nat\\projects\\prototype-kits\\session-data-defaults\\node_modules\\nowprototypeit\\lib\\session.js:92:12)
+    at Object.<anonymous> (C:\\Users\\nat\\projects\\prototype-kits\\session-data-defaults\\node_modules\\nowprototypeit\\lib\\session.js:98:29)`
+
+const windowsExample = `C:\\Users\\nat\\projects\\prototype-kits\\session-data-defaults\\app\\data\\session-data-defaults.js:2
+  'broken'
+  ^^^^^^^^
+
+SyntaxError: Unexpected string
+${windowsStackTrace}`
+
+const paths = require('./paths')
+const path = require('node:path')
+
+describe('errorModel', () => {
+  describe('parsing errors from stderr', () => {
+    let testScope
+    beforeEach(() => {
+      testScope = {}
+      testScope.origPaths = {
+        projectDir: paths.projectDir,
+        packageDir: paths.packageDir
+      }
+      testScope.origPathSep = path.sep
+    })
+    afterEach(() => {
+      paths.packageDir = testScope.origPaths.packageDir
+      paths.projectDir = testScope.origPaths.projectDir
+      path.sep = testScope.origPathSep
+    })
+    it('should parse Ubuntu Syntax Error stack trace', async () => {
+      paths.projectDir = '/home/natalie/projects/prototype-kits/now-prototype-it-companion/'
+      // const prep = prepareInput(ubuntuExample)
+      const result = await getErrorModelFromStderr(ubuntuExample)
+      expect(result.message).toBe('Unexpected string')
+      expect(result.type).toBe('SyntaxError')
+      expect(result.parsedBy).toBe('tryParsingNodeError')
+      expect(result.line).toBe(2)
+      expect(result.column).toBe(undefined)
+      expect(result.filePath).toBe('app/data/session-data-defaults.js')
+      expect(result.stackTrace).toBe(ubuntuStackTrace)
+      expect(result.fullError).toBe(ubuntuExample)
+    })
+    it('should parse Windows Syntax Error stack trace', async () => {
+      paths.projectDir = 'C:\\Users\\nat\\projects\\prototype-kits\\session-data-defaults'
+      path.sep = '\\'
+      const result = await getErrorModelFromStderr(windowsExample)
+      expect(result.message).toBe('Unexpected string')
+      expect(result.type).toBe('SyntaxError')
+      expect(result.parsedBy).toBe('tryParsingNodeError')
+      expect(result.line).toBe(2)
+      expect(result.column).toBe(undefined)
+      expect(result.filePath).toBe('\\app\\data\\session-data-defaults.js')
+      expect(result.stackTrace).toBe(windowsStackTrace)
+      expect(result.fullError).toBe(windowsExample)
+    })
+  })
+})


### PR DESCRIPTION
Previously if `session-data-defaults.js` failed (e.g. a syntax error) the default (empty) value would be used and the user would not be informed.  This changes that so that `session-data-defaults.js` errors are handled the same as errors in `routes.js` - the kit fails to start and the user is informed both in the browser and the terminal.

![A screenshot of the syntax error in the browser with the problematic line selected](https://github.com/user-attachments/assets/9b08ac91-6eec-4b02-bab9-8ca98068e58d)

![A screenshot of the syntax error in the terminal](https://github.com/user-attachments/assets/b43c5671-2062-4a7c-8b19-53418e744fec)

