### PR TITLE
Compatibility with latest govuk-frontend release (5.10.0) without affecting non-govuk prototypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+ - Allowing users to use the latest (5.10.0) `govuk-frontend` which directly references `govuk-prototype-kit` - this change will not negatively affect those prototyping outside GOV.UK
+
 ## 0.11.3
 
 ### Improvements

--- a/features/step-definitions/style.steps.js
+++ b/features/step-definitions/style.steps.js
@@ -41,26 +41,26 @@ Then('the first paragraph margin top should become {string}', styleBuildTimeout,
 })
 
 Then('I should see the crown icon in the footer', mediumActionTimeout, async function () {
-  await makeSureBackgroundImageCanBeLoaded(this.browser, this.kit.dir, mediumActionTimeout.timeout)
+  await makeSureMaskImageCanBeLoaded(this.browser, this.kit.dir, mediumActionTimeout.timeout)
 })
 
-async function makeSureBackgroundImageCanBeLoaded (browser, prototypeDir, timeout) {
+async function makeSureMaskImageCanBeLoaded (browser, prototypeDir, timeout) {
   const start = Date.now()
   let output = 'none'
-  while (output === 'none' && (start + timeout) > Date.now()) {
+  while ((output === 'none' || output === null) && (start + (timeout / 2)) > Date.now()) {
     await sleep(100)
     const element = (await browser.queryClass('govuk-footer__copyright-logo'))[0]
     if (element) {
-      output = await browser.driver.executeScript('const style = window.getComputedStyle(arguments[0]); return {backgroundImage: style.backgroundImage};', element)
+      output = await browser.driver.executeScript('return getComputedStyle(document.querySelector(".govuk-footer__copyright-logo"), ":before").getPropertyValue("mask-image")')
     }
   }
 
-  const [before, url, after] = output.backgroundImage.split('"')
+  const [before, url, after] = output.split('"')
   ;(await expect(before)).to.equal('url(')
   ;(await expect(after)).to.equal(')')
   const filePathFromNodeModules = url.split('plugin-assets/')[1]
   if (!filePathFromNodeModules) {
-    throw new Error(`No file path could be found (looking for background image) [${output.backgroundImage}]`)
+    throw new Error(`No file path could be found (looking for mask image) [${output}]`)
   }
   const filePath = path.join(prototypeDir, 'node_modules', filePathFromNodeModules)
   const fileOnFileSystem = await fsp.readFile(filePath, 'utf8')

--- a/lib/dev-server/manage-prototype/manage-prototype-runner.js
+++ b/lib/dev-server/manage-prototype/manage-prototype-runner.js
@@ -46,6 +46,7 @@ events.on(eventTypes.KIT_STARTED, (obj) => {
   events.emit(eventTypes.RELOAD_PAGE)
 
   if (isFirst) {
+    console.log('')
     console.log('You can manage your prototype at:')
     console.log(`http://localhost:${port}/manage-prototype`)
     console.log('')

--- a/lib/utils/replace-require.js
+++ b/lib/utils/replace-require.js
@@ -1,0 +1,19 @@
+const Module = require('module')
+const path = require('path')
+
+module.exports = {
+  replaceRequire: () => {
+    const originalRequire = Module.prototype.require
+    Module.prototype.require = function (modulePath) {
+      if (modulePath === 'govuk-prototype-kit') {
+        console.log('We replaced a require(\'govuk-prototype-kit\') with require(\'nowprototypeit\')')
+        return originalRequire.call(this, path.join(__dirname, '..', '..', 'index.js'))
+      }
+      if (modulePath === 'govuk-prototype-kit/lib/config.js') {
+        console.log('We replaced a require(\'govuk-prototype-kit/lib/config.js\') with require(\'nowprototypeit/lib/config.js\')')
+        return originalRequire.call(this, path.join(__dirname, '..', 'config.js'))
+      }
+      return originalRequire.call(this, modulePath)
+    }
+  }
+}

--- a/listen-on-port.js
+++ b/listen-on-port.js
@@ -1,4 +1,5 @@
 const config = require('./lib/config.js').getConfig(null, false)
+require('./lib/utils/replace-require').replaceRequire()
 const server = require('./server.js')
 
 if (config.isProduction) {


### PR DESCRIPTION
About 3 hours ago a release of `govuk-frontend` came out which refers directly to `govuk-prototype-kit` - this causes `nowprototypeit` prototypes to crash as `govuk-prototype-kit` isn't installed.

`nowprototypeit` started life as a fork of `govuk-prototype-kit` and maintains compatibility with the tooling.

We have considered this change for a while but we dislike overriding user's code.  In this case the challenge users would face if we do nothing is just too big. Our long-term plan is:

 - To use `require('prototype-core')` instead of `require('nowprototypeit')` so that any fork of `nowprototypeit` doesn't have to handle problems like this
 - To consider introducing a mechanism to allow plugins to control some of this behaviour (we're not introducing that right now as it would require careful consideration)
 - To form a better working relationship with teams across GOV.UK, helping them to make use of the features of `nowprototypeit` the best they can

In this case, [the update to govuk-frontend](https://github.com/alphagov/govuk-frontend/pull/5877) is all about settings, in a `nowprototypeit` environment [these settings can be added to the plugin configuration and controlled in the browser by the user of the prototype](https://github.com/nowprototypeit/adaptors/blob/1fdd010/govuk-frontend-adaptor/now-prototype-it.config.json#L54-L127) (right now we maintain this adaptor but it's open source and anyone is welcome to fork it and publish their own version).

We have added a log line when this behaviour is used so that the user is informed.

Happy prototyping, whatever tools you're using!