### PR TITLE
Adding a basic test for the hosting environment to avoid regressions.

### DIFF
--- a/features/hosting/hosting.feature
+++ b/features/hosting/hosting.feature
@@ -1,0 +1,7 @@
+Feature: Hosting
+
+@no-variant
+@hosting-experiment-on
+Scenario: Hosting
+  When I visit "/manage-prototype/hosting"
+  Then the page should include a paragraph that reads "To start hosting you'll need to log in to your nowprototype.it account."

--- a/features/step-definitions/hooks.steps.js
+++ b/features/step-definitions/hooks.steps.js
@@ -17,6 +17,9 @@ const experimentTagSettings = {
   },
   '@edit-in-browser-experiment-on': {
     editInBrowser: true
+  },
+  '@hosting-experiment-on': {
+    hostingEnabled: true
   }
 }
 


### PR DESCRIPTION
I hadn't previously included tests for the hosting platform as it would require logins etc.

The long-term plan is to have a test-harness which mimics the interactions with the hosting platform (which would also serve as a blueprint for anyone who wants to build their own hosting platform for Now Prototype It prototypes).  I realised that I need to make sure the basics work across multiple node versions and operating systems and I'm not managing to do that manually.

This test just makes sure that the page loads with the right content.