### PR TITLE
Fixing messages from the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+ - The messages from the API was [broken in release 0.10.0](https://github.com/nowprototypeit/nowprototypeit/compare/v0.9.5...v0.10.0#diff-d5109920b34c2b2e141bd41232d8876432a17479c388e142d8a036bb7b36ea62L94-L105) and we didn't have a test for it.  We have now introduced a fake API into the tests in order to cover behaviour which relies on the API.  These messages are intended to encourage users to keep their Now Prototype It version up-to-date and to inform them if any issues become known about earlier versions - including security issues and incompatabilities.
+
 ## 0.12.0
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
  - The messages from the API was [broken in release 0.10.0](https://github.com/nowprototypeit/nowprototypeit/compare/v0.9.5...v0.10.0#diff-d5109920b34c2b2e141bd41232d8876432a17479c388e142d8a036bb7b36ea62L94-L105) and we didn't have a test for it.  We have now introduced a fake API into the tests in order to cover behaviour which relies on the API.  These messages are intended to encourage users to keep their Now Prototype It version up-to-date and to inform them if any issues become known about earlier versions - including security issues and incompatabilities.
 
+### Improvements
+
+ - Previously messages from the API could only be plain text and could have a link URL specified.  Now they can use a limited set of rich text and provide links.  For security reasons link ULRs are shown to the user and formatting is limited to bold and italic.
+ - Previously the API could send any HTML elements to communicate with the user when their prototype was using a dependency which was too old, that's now using the same minimalist rich text format as the messages.  This is to prevent the API from being able to send unexpected HTML to the user.
+
 ## 0.12.0
 
 ### New Features

--- a/features/hosting/hosting.feature
+++ b/features/hosting/hosting.feature
@@ -1,7 +1,0 @@
-Feature: Hosting
-
-@no-variant
-@hosting-experiment-on
-Scenario: Hosting
-  When I visit "/manage-prototype/hosting"
-  Then the page should include a paragraph that reads "To start hosting you'll need to log in to your nowprototype.it account."

--- a/features/manage-prototype/hosting.feature
+++ b/features/manage-prototype/hosting.feature
@@ -1,0 +1,22 @@
+Feature: Hosting
+
+@no-variant
+@hosting-experiment-on
+Scenario: Hosting message
+  Given Hosting is enabled for this version of the kit with logged out message "<p>This is an example <strong>from the fake API</strong>.</p>"
+  When I visit "/manage-prototype/hosting"
+  Then the page should include a paragraph that reads "This is an example from the fake API."
+
+@no-variant
+@hosting-experiment-on
+Scenario: Hosting page with a different message
+  Given Hosting is enabled for this version of the kit with logged out message "<p>Basic text</p>"
+  When I visit "/manage-prototype/hosting"
+  Then the page should include a paragraph that reads "Basic text"
+
+@no-variant
+@hosting-experiment-on
+Scenario: Incompatible version
+  Given Hosting is disabled for this version of the kit with message "<p>Please <a href='/'>update your kit</a> to use the hosting platform.</p>"
+  When I visit "/manage-prototype/hosting"
+  Then the page should include a paragraph that reads "Please update your kit to use the hosting platform."

--- a/features/manage-prototype/hosting.feature
+++ b/features/manage-prototype/hosting.feature
@@ -17,6 +17,16 @@ Scenario: Hosting page with a different message
 @no-variant
 @hosting-experiment-on
 Scenario: Incompatible version
-  Given Hosting is disabled for this version of the kit with message "<p>Please <a href='/'>update your kit</a> to use the hosting platform.</p>"
+  Given Hosting is disabled for this version of the kit with message "This **should** be *formatted* and can include links (link:/manage-prototype/plugin/npm:nowprototypeit)"
   When I visit "/manage-prototype/hosting"
-  Then the page should include a paragraph that reads "Please update your kit to use the hosting platform."
+  Then the page should include a paragraph that reads "This should be formatted and can include links /manage-prototype/plugin/npm:nowprototypeit"
+  And the page should contain bold text saying "should"
+  And the page should contain italic text saying "formatted"
+  And the page should contain a link with URL and text of "/manage-prototype/plugin/npm:nowprototypeit"
+
+@no-variant
+@hosting-experiment-on
+Scenario: Incompatible version with a different message
+  Given Hosting is disabled for this version of the kit with message "Basic message"
+  When I visit "/manage-prototype/hosting"
+  Then the page should include a paragraph that reads "Basic message"

--- a/features/manage-prototype/messages.feature
+++ b/features/manage-prototype/messages.feature
@@ -2,17 +2,27 @@
 Feature: Messages from the API
 
   Scenario: Read a messages from the API
-    Given the API contains a message for this version of the kit saying "Hello, and welcome"
+    Given the API contains a message for this version of the kit with text "Hello, and welcome"
     And I fully restart my prototype
     When I visit the manage prototype homepage
     Then I should only see the message "Hello, and welcome"
 
-  Scenario: Read a different messages from the API
-    Given the API contains a message for this version of the kit saying "This is a message from the API, it's used for communicating known issues with older versions."
+  Scenario: Pass on HTML elements as text
+    Given the API contains a message for this version of the kit with text "<p>This is a message <script>window.location.href='https://example.com'</script> from the API, it's used for communicating known issues with older versions.</p>"
     And I fully restart my prototype
     When I visit the manage prototype homepage
-    Then I should only see the message "This is a message from the API, it's used for communicating known issues with older versions."
+    Then I should only see the message "<p>This is a message <script>window.location.href='https://example.com'</script> from the API, it's used for communicating known issues with older versions.</p>"
 
   Scenario: No API messages by default
     When I visit the manage prototype homepage
     Then I should not see any messages
+
+  Scenario: Allow styled content from the API
+    Given the API contains a message for this version of the kit with text "This is a **MAJOR** *security issue* with the prototype kit **please**, update as soon as you can.  You can do that by visiting (link:/manage-prototype/plugin/npm:nowprototypeit)."
+    And I fully restart my prototype
+    When I visit the manage prototype homepage
+    Then I should only see the message "This is a MAJOR security issue with the prototype kit please, update as soon as you can.  You can do that by visiting /manage-prototype/plugin/npm:nowprototypeit."
+    And the first message should contain bold text saying "MAJOR"
+    And the first message should contain bold text saying "please"
+    And the first message should contain italic text saying "security issue"
+    And the first message should contain a link to "/manage-prototype/plugin/npm:nowprototypeit"

--- a/features/manage-prototype/messages.feature
+++ b/features/manage-prototype/messages.feature
@@ -1,0 +1,18 @@
+@no-variant
+Feature: Messages from the API
+
+  Scenario: Read a messages from the API
+    Given the API contains a message for this version of the kit saying "Hello, and welcome"
+    And I fully restart my prototype
+    When I visit the manage prototype homepage
+    Then I should only see the message "Hello, and welcome"
+
+  Scenario: Read a different messages from the API
+    Given the API contains a message for this version of the kit saying "This is a message from the API, it's used for communicating known issues with older versions."
+    And I fully restart my prototype
+    When I visit the manage prototype homepage
+    Then I should only see the message "This is a message from the API, it's used for communicating known issues with older versions."
+
+  Scenario: No API messages by default
+    When I visit the manage prototype homepage
+    Then I should not see any messages

--- a/features/step-definitions/general.steps.js
+++ b/features/step-definitions/general.steps.js
@@ -230,3 +230,6 @@ When('I restart my prototype by updating the file {string}', { timeout: 30 * 100
 Then('I intentionally fail the tests', function () {
   throw new Error('Intentional failure')
 })
+Given('I fully restart my prototype', standardTimeout, function () {
+  return this.kit.restart()
+})

--- a/features/step-definitions/general.steps.js
+++ b/features/step-definitions/general.steps.js
@@ -235,3 +235,29 @@ Then('I intentionally fail the tests', function () {
 Given('I fully restart my prototype', standardTimeout, function () {
   return this.kit.restart()
 })
+
+Then('the page should contain bold text saying {string}', standardTimeout, async function (boldTextContent) {
+  const boldText = await this.browser.getTextFromSelectorAll('strong')
+  if (!boldText.includes(boldTextContent)) {
+    throw new Error(`Expected bold text to contain [${boldTextContent}], but found [${boldText.join(', ')}]`)
+  }
+})
+
+Then('the page should contain italic text saying {string}', standardTimeout, async function (boldTextContent) {
+  const boldText = await this.browser.getTextFromSelectorAll('em')
+  if (!boldText.includes(boldTextContent)) {
+    throw new Error(`Expected bold text to contain [${boldTextContent}], but found [${boldText.join(', ')}]`)
+  }
+})
+
+Then('the page should contain a link with URL and text of {string}', standardTimeout, async function (linkTextAndUrl) {
+  const linkTextAndUrlList = await this.browser.getLinkTextAndUrlFromSelectorAll('a')
+  const index = linkTextAndUrlList.findIndex(x => x.text === linkTextAndUrl)
+  if (index === -1) {
+    throw new Error(`Expected link to contain [${linkTextAndUrl}], but found [${linkTextAndUrlList.map(x => x.text).join(', ')}]`)
+  }
+  const found = linkTextAndUrlList[index]
+  if (found.text !== found.url) {
+    throw new Error(`Expected link text to be the same as the URL, but found text [${found.text}] and url [${found.url}]`)
+  }
+})

--- a/features/step-definitions/general.steps.js
+++ b/features/step-definitions/general.steps.js
@@ -36,7 +36,9 @@ Then('the main heading should read {string}', standardTimeout, async function (e
 
 Then('the page should include a paragraph that reads {string}', standardTimeout, async function (expectedHeading) {
   const allPText = await this.browser.getTextFromSelectorAll('p')
-  ;(await expect(allPText)).to.include(expectedHeading)
+  if (!allPText.includes(expectedHeading)) {
+    throw new Error(`Expected to find paragraph with text [${expectedHeading}] but found [${allPText.join(', ')}]`)
+  }
 })
 
 Then('the first paragraph should read {string}', standardTimeout, async function (expectedHeading) {

--- a/features/step-definitions/hooks.steps.js
+++ b/features/step-definitions/hooks.steps.js
@@ -63,6 +63,9 @@ function getVariantConfig (variantTag) {
   return result
 }
 
+Before(standardTimeout, async function () {
+  console.log('') // without this the 'first' dot in each run is actually the cleanup from the last run.
+})
 const configuredToLogEachStep = process.env.LOG_EACH_STEP === 'true'
 if (configuredToLogEachStep) {
   BeforeStep(standardTimeout, async function (scenario) {
@@ -154,6 +157,7 @@ After(kitStartTimeout, async function (scenario) {
   }
   if (!this.kit?.neverReuseThisKit) {
     await this.kit?.reset()
+    await this.fakeApi?.reset()
     await this.browser?.openUrl('about:blank')
   }
   if (process.env.DELAY_BETWEEN_TESTS) {
@@ -186,6 +190,8 @@ AfterAll(kitStartTimeout, async function () {
     console.log('')
   }
 
+  console.log('')
+  console.log('')
   console.log('Starting cleanup')
   await runShutdownFunctions()
   console.log('Cleanup complete')

--- a/features/step-definitions/hooks.steps.js
+++ b/features/step-definitions/hooks.steps.js
@@ -63,9 +63,6 @@ function getVariantConfig (variantTag) {
   return result
 }
 
-Before(standardTimeout, async function () {
-  console.log('') // without this the 'first' dot in each run is actually the cleanup from the last run.
-})
 const configuredToLogEachStep = process.env.LOG_EACH_STEP === 'true'
 if (configuredToLogEachStep) {
   BeforeStep(standardTimeout, async function (scenario) {
@@ -79,6 +76,7 @@ if (configuredToLogEachStep) {
 }
 
 Before(kitStartTimeout, async function (scenario) {
+  console.log('') // without this the 'first' dot in each run is actually the cleanup from the last run.
   const tagNames = scenario.pickle.tags.map(x => x.name)
   const variantTags = tagNames.filter(x => x.endsWith('-variant') || x.startsWith('@kit-update'))
   if (variantTags.length > 1) {
@@ -126,9 +124,9 @@ After(kitStartTimeout, async function (scenario) {
     anyFailures = true
     console.log('')
     console.log(' - - - ')
-    console.log('Full kit stderr:')
+    console.log('Full kit stdout & stderr:')
     console.log('')
-    console.log(this.kit?.getFullStderr())
+    console.log(this.kit?.getFullStdoutAndStdErr())
     console.log('')
     console.log(' - - - ')
     console.log('')

--- a/features/step-definitions/manage-prototype.steps.js
+++ b/features/step-definitions/manage-prototype.steps.js
@@ -1,0 +1,29 @@
+const { Given, Then, When } = require('@cucumber/cucumber')
+const { standardTimeout } = require('./setup-helpers/timeouts')
+const { expect } = require('./utils')
+
+Given('the API contains a message for this version of the kit saying {string}', standardTimeout, function (messageText) {
+  this.fakeApi.setMessagesForVersion(this.kit.version, false, [
+    { text: messageText }
+  ])
+})
+
+When('I visit the manage prototype homepage', standardTimeout, async function () {
+  await this.browser.openUrl('/manage-prototype')
+})
+
+Then('I should only see the message {string}', standardTimeout, async function (oneAndOnlyMessage) {
+  const messages = await this.browser.getTextFromSelectorAll('.nowprototypeit-manage-prototype-messages li')
+  ;(await expect(messages)).to.contain(oneAndOnlyMessage)
+  const length = messages.length
+  if (length > 1) {
+    throw new Error(`Expected only one message, but found ${length}: ${messages.join(', ')}`)
+  }
+})
+
+Then('I should not see any messages', standardTimeout, async function () {
+  const messagesElementExists = await this.browser.hasSelector('.nowprototypeit-manage-prototype-messages')
+  if (messagesElementExists) {
+    throw new Error('Expected no messages, but found the messages element')
+  }
+})

--- a/features/step-definitions/manage-prototype.steps.js
+++ b/features/step-definitions/manage-prototype.steps.js
@@ -8,6 +8,14 @@ Given('the API contains a message for this version of the kit saying {string}', 
   ])
 })
 
+Given('Hosting is enabled for this version of the kit with logged out message {string}', standardTimeout, async function (message) {
+  await this.fakeApi.setHostingConfigForVersion(this.kit.version, true, message)
+})
+
+Given('Hosting is disabled for this version of the kit with message {string}', standardTimeout, async function (message) {
+  await this.fakeApi.setHostingConfigForVersion(this.kit.version, false, message)
+})
+
 When('I visit the manage prototype homepage', standardTimeout, async function () {
   await this.browser.openUrl('/manage-prototype')
 })

--- a/features/step-definitions/setup-helpers/browser.js
+++ b/features/step-definitions/setup-helpers/browser.js
@@ -104,6 +104,13 @@ async function getBrowser (config = {}) {
       const elemContents = await Promise.all($$elems.map(async x => await x.textContent()))
       return elemContents.map(x => x?.trim())
     },
+    getLinkTextAndUrlFromSelectorAll: async (selector, timeoutDeclaration = standardTimeout) => {
+      const $$elems = await page.$$(selector)
+      return await Promise.all($$elems.map(async x => ({
+        text: (await x.textContent())?.trim(),
+        url: await x.getAttribute('href')
+      })))
+    },
     getTitle: async () => {
       return await page.title()
     },

--- a/features/step-definitions/setup-helpers/fake-api.js
+++ b/features/step-definitions/setup-helpers/fake-api.js
@@ -1,0 +1,50 @@
+const { fork } = require('../../../lib/exec')
+const path = require('node:path')
+const { findAvailablePortWithoutUser } = require('./findPort')
+const { addShutdownFn } = require('../../../lib/utils/shutdownHandlers')
+
+async function setupFakeApi () {
+  const port = await findAvailablePortWithoutUser()
+  const showFakeApiLogs = process.env.SHOW_FAKE_API_STDIO === 'true'
+  const forked = fork(path.join(__dirname, 'fake-api', 'start-fake-api-entrypoint.js'), {
+    env: {
+      PORT: port,
+      NPI_OS_API__LOG_ALL_REQUESTS: '' + showFakeApiLogs
+    },
+    hideStdout: showFakeApiLogs,
+    hideStderr: showFakeApiLogs
+  })
+
+  const baseUrl = `http://localhost:${port}`
+
+  async function setMessagesForVersion (version, upgradeAvailable, messages) {
+    await fetch(baseUrl + `/v1/messages/npi/${encodeURIComponent(version)}`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        version,
+        upgradeAvailable,
+        messages
+      })
+    })
+  }
+
+  async function close () {
+    if (forked.open) {
+      await forked.close()
+    }
+  }
+
+  addShutdownFn(close)
+  return {
+    baseUrl,
+    setMessagesForVersion,
+    close
+  }
+}
+
+module.exports = {
+  setupFakeApi
+}

--- a/features/step-definitions/setup-helpers/fake-api.js
+++ b/features/step-definitions/setup-helpers/fake-api.js
@@ -3,7 +3,12 @@ const path = require('node:path')
 const { findAvailablePortWithoutUser } = require('./findPort')
 const { addShutdownFn } = require('../../../lib/utils/shutdownHandlers')
 
+let singletonFakeApi = null
+
 async function setupFakeApi () {
+  if (singletonFakeApi) {
+    return singletonFakeApi
+  }
   const port = await findAvailablePortWithoutUser()
   const showFakeApiLogs = process.env.SHOW_FAKE_API_STDIO === 'true'
   const forked = fork(path.join(__dirname, 'fake-api', 'start-fake-api-entrypoint.js'), {
@@ -11,11 +16,30 @@ async function setupFakeApi () {
       PORT: port,
       NPI_OS_API__LOG_ALL_REQUESTS: '' + showFakeApiLogs
     },
-    hideStdout: showFakeApiLogs,
-    hideStderr: showFakeApiLogs
+    hideStdout: !showFakeApiLogs,
+    hideStderr: !showFakeApiLogs
   })
 
   const baseUrl = `http://localhost:${port}`
+
+  async function setHostingConfigForVersion (version, isCompatible, message) {
+    const body = {
+      isCompatible
+    }
+    if (isCompatible) {
+      body.loggedOutMessage = message
+      body.hostingBaseUrl = 'https://localhost:9999999' // I've specified an out of range port as we don't have a real URL yet
+    }
+    body.messageHtml = message
+
+    await fetch(baseUrl + `/v1/hosting-config-for-nowprototypeit/${encodeURIComponent(version)}`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(body)
+    })
+  }
 
   async function setMessagesForVersion (version, upgradeAvailable, messages) {
     await fetch(baseUrl + `/v1/messages/npi/${encodeURIComponent(version)}`, {
@@ -31,6 +55,12 @@ async function setupFakeApi () {
     })
   }
 
+  async function reset () {
+    await fetch(baseUrl + '/__reset-everything__', {
+      method: 'POST'
+    })
+  }
+
   async function close () {
     if (forked.open) {
       await forked.close()
@@ -38,11 +68,15 @@ async function setupFakeApi () {
   }
 
   addShutdownFn(close)
-  return {
+  const self = {
     baseUrl,
     setMessagesForVersion,
-    close
+    setHostingConfigForVersion,
+    close,
+    reset
   }
+  singletonFakeApi = self
+  return self
 }
 
 module.exports = {

--- a/features/step-definitions/setup-helpers/fake-api.js
+++ b/features/step-definitions/setup-helpers/fake-api.js
@@ -30,7 +30,7 @@ async function setupFakeApi () {
       body.loggedOutMessage = message
       body.hostingBaseUrl = 'https://localhost:9999999' // I've specified an out of range port as we don't have a real URL yet
     }
-    body.messageHtml = message
+    body.messageFormattedText = message
 
     await fetch(baseUrl + `/v1/hosting-config-for-nowprototypeit/${encodeURIComponent(version)}`, {
       method: 'PUT',

--- a/features/step-definitions/setup-helpers/fake-api/routers/hosting.js
+++ b/features/step-definitions/setup-helpers/fake-api/routers/hosting.js
@@ -1,0 +1,46 @@
+const express = require('express')
+
+const hostingConfigResponseByKitVersion = {}
+let defaultHostingConfigResponse = {}
+
+function resetHosting () {
+  defaultHostingConfigResponse = {
+    isCompatible: false,
+    messageHtml: 'This is the default for the fake API'
+  }
+  Object.keys(hostingConfigResponseByKitVersion).forEach(key => {
+    delete hostingConfigResponseByKitVersion[key]
+  })
+}
+
+const hostingRouter = express.Router()
+resetHosting()
+
+hostingRouter.get('/v1/hosting-config-for-nowprototypeit/:version', (req, res) => {
+  const version = req.params.version
+  const messages = hostingConfigResponseByKitVersion[version] || replaceVarsInDefaultMessage({ version })
+  res.json(messages)
+})
+
+hostingRouter.put('/v1/hosting-config-for-nowprototypeit/__default__', [express.json()], (req, res) => {
+  defaultHostingConfigResponse = { ...req.body }
+  res.send({ success: true })
+})
+
+hostingRouter.put('/v1/hosting-config-for-nowprototypeit/:version', [express.json()], (req, res) => {
+  hostingConfigResponseByKitVersion[req.params.version] = { ...req.body }
+  console.log(`set hosting config for version [${req.params.version}]`, hostingConfigResponseByKitVersion[req.params.version])
+  res.send({ success: true })
+})
+
+module.exports = {
+  resetHosting,
+  hostingRouter
+}
+
+function replaceVarsInDefaultMessage (vars = {}) {
+  return Object.keys(defaultHostingConfigResponse).reduce((acc, key) => {
+    acc[key] = vars[key] ?? defaultHostingConfigResponse[key]
+    return acc
+  }, {})
+}

--- a/features/step-definitions/setup-helpers/fake-api/routers/messages.js
+++ b/features/step-definitions/setup-helpers/fake-api/routers/messages.js
@@ -1,0 +1,45 @@
+const express = require('express')
+
+const messagesByKitVersion = {}
+let defaultMessagesResponse = {}
+
+function resetMessages () {
+  defaultMessagesResponse = {
+    upgradeAvailable: false,
+    messages: []
+  }
+  Object.keys(messagesByKitVersion).forEach(key => {
+    delete messagesByKitVersion[key]
+  })
+}
+
+const messagesRouter = express.Router()
+resetMessages()
+
+messagesRouter.get('/:version', (req, res) => {
+  const version = req.params.version
+  const messages = messagesByKitVersion[version] || replaceVarsInDefaultMessage({ version })
+  res.json(messages)
+})
+
+messagesRouter.put('/__default__', [express.json()], (req, res) => {
+  defaultMessagesResponse = { ...req.body }
+  res.send({ success: true })
+})
+
+messagesRouter.put('/:version', [express.json()], (req, res) => {
+  messagesByKitVersion[req.params.version] = { ...req.body, version: req.params.version }
+  res.send({ success: true })
+})
+
+module.exports = {
+  resetMessages,
+  messagesRouter
+}
+
+function replaceVarsInDefaultMessage (vars = {}) {
+  return Object.keys(defaultMessagesResponse).reduce((acc, key) => {
+    acc[key] = vars[key] ?? defaultMessagesResponse[key]
+    return acc
+  }, {})
+}

--- a/features/step-definitions/setup-helpers/fake-api/routers/messages.js
+++ b/features/step-definitions/setup-helpers/fake-api/routers/messages.js
@@ -16,18 +16,18 @@ function resetMessages () {
 const messagesRouter = express.Router()
 resetMessages()
 
-messagesRouter.get('/:version', (req, res) => {
+messagesRouter.get('/v1/messages/npi/:version', (req, res) => {
   const version = req.params.version
   const messages = messagesByKitVersion[version] || replaceVarsInDefaultMessage({ version })
   res.json(messages)
 })
 
-messagesRouter.put('/__default__', [express.json()], (req, res) => {
+messagesRouter.put('/v1/messages/npi/__default__', [express.json()], (req, res) => {
   defaultMessagesResponse = { ...req.body }
   res.send({ success: true })
 })
 
-messagesRouter.put('/:version', [express.json()], (req, res) => {
+messagesRouter.put('/v1/messages/npi/:version', [express.json()], (req, res) => {
   messagesByKitVersion[req.params.version] = { ...req.body, version: req.params.version }
   res.send({ success: true })
 })

--- a/features/step-definitions/setup-helpers/fake-api/start-fake-api-entrypoint.js
+++ b/features/step-definitions/setup-helpers/fake-api/start-fake-api-entrypoint.js
@@ -1,0 +1,38 @@
+if (require.main === module) {
+  const { listenForShutdown } = require('../../../../lib/utils/shutdownHandlers')
+  listenForShutdown('opensource api setup for tests')
+  const express = require('express')
+  const { resetMessages, messagesRouter } = require('./routers/messages.js')
+
+  const app = express()
+  const port = process.env.PORT
+  const logAllRequests = process.env.NPI_OS_API__LOG_ALL_REQUESTS === 'true'
+
+  if (!port || isNaN(port)) {
+    console.error('No valid PORT environment variable provided')
+    throw new Error('this process requires a PORT environment variable')
+  }
+
+  if (logAllRequests) {
+    app.use((req, res, next) => {
+      console.log('Request:', req.method, req.url)
+      next()
+    })
+  }
+
+  app.post('/__reset-everything__', (req, res) => {
+    resetMessages()
+  })
+
+  app.use('/v1/messages/npi/', messagesRouter)
+
+  app.use((req, res) => {
+    res.status(405)
+    res.setHeader('Allow', '')
+    res.send({ error: 'Method not allowed, this endpoint may not exist.' })
+  })
+
+  const listener = app.listen(port, () => {
+    console.log(`Fake API is listening on http://localhost:${listener.address().port}/`)
+  })
+}

--- a/features/step-definitions/setup-helpers/fake-api/start-fake-api-entrypoint.js
+++ b/features/step-definitions/setup-helpers/fake-api/start-fake-api-entrypoint.js
@@ -3,6 +3,7 @@ if (require.main === module) {
   listenForShutdown('opensource api setup for tests')
   const express = require('express')
   const { resetMessages, messagesRouter } = require('./routers/messages.js')
+  const { resetHosting, hostingRouter } = require('./routers/hosting.js')
 
   const app = express()
   const port = process.env.PORT
@@ -22,9 +23,12 @@ if (require.main === module) {
 
   app.post('/__reset-everything__', (req, res) => {
     resetMessages()
+    resetHosting()
+    res.send({ success: true })
   })
 
-  app.use('/v1/messages/npi/', messagesRouter)
+  app.use(messagesRouter)
+  app.use(hostingRouter)
 
   app.use((req, res) => {
     res.status(405)

--- a/features/step-definitions/setup-helpers/kit.js
+++ b/features/step-definitions/setup-helpers/kit.js
@@ -72,9 +72,12 @@ async function setupKit (options) {
   }
   kitThread.stdio.stdout.on('data', listener)
 
-  let fullStderr = ''
+  let fullStdoutAndStderr = ''
   kitThread.stdio.stderr.on('data', (data) => {
-    fullStderr += data.toString()
+    fullStdoutAndStderr += data.toString()
+  })
+  kitThread.stdio.stdout.on('data', (data) => {
+    fullStdoutAndStderr += data.toString()
   })
 
   await kitStartedPromiseParts.promise
@@ -139,7 +142,7 @@ async function setupKit (options) {
     close,
     reset: close,
     addNextKitRestartListener,
-    getFullStderr: () => fullStderr,
+    getFullStdoutAndStdErr: () => fullStdoutAndStderr,
     restart
   }
 }

--- a/features/step-definitions/setup-helpers/timeouts.js
+++ b/features/step-definitions/setup-helpers/timeouts.js
@@ -8,7 +8,7 @@ const standardTimeout = { timeout: 5 * 1000 * timeoutMultiplier }
 
 module.exports = {
   timeoutMultiplier,
-  kitStartTimeout: { timeout: (process.env.TEST_KIT_DEPENDENCY ? 90 : 40) * 1000 * timeoutMultiplier },
+  kitStartTimeout: { timeout: (process.env.TEST_KIT_DEPENDENCY ? 30 : 20) * 1000 * timeoutMultiplier },
   standardTimeout,
   tinyTimeout: { timeout: 0.5 * 1000 * timeoutMultiplier },
   pluginActionTimeout: { timeout: 60 * 1000 * timeoutMultiplier },

--- a/lib/dev-server/dev-server.js
+++ b/lib/dev-server/dev-server.js
@@ -64,6 +64,7 @@ events.on(eventTypes.KIT_STOPPED, async (info) => {
 
 const commands = {
   rs: () => {
+    console.log('Restarting...')
     events.emit(eventTypes.TRIGGER_KIT_RESTART)
     events.emit(eventTypes.MANAGEMENT_RESTART)
   },

--- a/lib/dev-server/manage-prototype/assets/sass/styles.scss
+++ b/lib/dev-server/manage-prototype/assets/sass/styles.scss
@@ -95,3 +95,7 @@
 #spinner-to-replace-with-on-submit {
   display: none;
 }
+
+.nowprototypeit-manage-prototype-messages__item {
+  margin-bottom: 1rem;
+}

--- a/lib/dev-server/manage-prototype/routes/management-pages/basicPages.js
+++ b/lib/dev-server/manage-prototype/routes/management-pages/basicPages.js
@@ -8,9 +8,13 @@ const kitVersion = require('../../../../../package.json').version
 const { getConfig } = require('../../../../config')
 const { findPagesInUsersKit } = require('../../../../utils')
 const { projectDir } = require('../../../../utils/paths')
+const { verboseLog } = require('../../../../utils/verboseLogger')
 
-const url = `${getConfig().npiApiBaseUrl}/v1/messages/npi/${encodeURIComponent(kitVersion)}`
-const messagesPromise = requestHttpsJson(url, {}).catch(() => null)
+const url = `${getConfig().nowPrototypeItAPIBaseUrl}/v1/messages/npi/${encodeURIComponent(kitVersion)}`
+const messagesPromise = requestHttpsJson(url, {}).catch((e) => {
+  verboseLog('Error fetching messages from NPI API with URL', url)
+  verboseLog('Error fetching messages from NPI API', e)
+})
 
 function getModel (currentSection, req) {
   return {

--- a/lib/dev-server/manage-prototype/routes/management-pages/basicPages.js
+++ b/lib/dev-server/manage-prototype/routes/management-pages/basicPages.js
@@ -9,12 +9,23 @@ const { getConfig } = require('../../../../config')
 const { findPagesInUsersKit } = require('../../../../utils')
 const { projectDir } = require('../../../../utils/paths')
 const { verboseLog } = require('../../../../utils/verboseLogger')
+const { addShutdownFn } = require('../../../../utils/shutdownHandlers')
 
 const url = `${getConfig().nowPrototypeItAPIBaseUrl}/v1/messages/npi/${encodeURIComponent(kitVersion)}`
-const messagesPromise = requestHttpsJson(url, {}).catch((e) => {
-  verboseLog('Error fetching messages from NPI API with URL', url)
-  verboseLog('Error fetching messages from NPI API', e)
+let messagesPromise = null
+
+function updateMessages () {
+  messagesPromise = requestHttpsJson(url, {}).catch((e) => {
+    verboseLog('Error fetching messages from NPI API with URL', url)
+    verboseLog('Error fetching messages from NPI API', e)
+  })
+}
+
+const messagesPollInterval = setInterval(updateMessages, 20 * 60 * 1000)
+addShutdownFn(() => {
+  clearInterval(messagesPollInterval)
 })
+updateMessages()
 
 function getModel (currentSection, req) {
   return {

--- a/lib/dev-server/manage-prototype/routes/management-pages/basicPages.js
+++ b/lib/dev-server/manage-prototype/routes/management-pages/basicPages.js
@@ -10,12 +10,13 @@ const { findPagesInUsersKit } = require('../../../../utils')
 const { projectDir } = require('../../../../utils/paths')
 const { verboseLog } = require('../../../../utils/verboseLogger')
 const { addShutdownFn } = require('../../../../utils/shutdownHandlers')
+const { prepareMessagesFromApi } = require('../../utils/prepare-messsages-from-api')
 
 const url = `${getConfig().nowPrototypeItAPIBaseUrl}/v1/messages/npi/${encodeURIComponent(kitVersion)}`
 let messagesPromise = null
 
 function updateMessages () {
-  messagesPromise = requestHttpsJson(url, {}).catch((e) => {
+  messagesPromise = requestHttpsJson(url, {}).then(prepareMessagesFromApi).catch((e) => {
     verboseLog('Error fetching messages from NPI API with URL', url)
     verboseLog('Error fetching messages from NPI API', e)
   })
@@ -38,13 +39,10 @@ function getModel (currentSection, req) {
 module.exports = {
   setupBasicPages: (router, config) => {
     router.get('/', async (req, res) => {
-      const messagesResponse = await awaitOrResolveWithDefault(messagesPromise, 500, null)
-      const messages = messagesResponse?.messages
-      const upgradeAvailable = messagesResponse?.upgradeAvailable
+      const messages = await awaitOrResolveWithDefault(messagesPromise, 500, null)
       res.render('index', {
         ...getModel('Home', req),
         messages,
-        upgradeAvailable,
         foundPages: findPagesInUsersKit()
       })
     })

--- a/lib/dev-server/manage-prototype/routes/management-pages/hosting.js
+++ b/lib/dev-server/manage-prototype/routes/management-pages/hosting.js
@@ -12,6 +12,8 @@ const { getPageNavLinks } = require('../../utils')
 const { projectDir, tmpDir } = require('../../../../utils/paths')
 const { getConfig } = require('../../../../config')
 const bodyParser = require('body-parser')
+
+const { prepareMessageFromApiAsHtml } = require('../../utils/prepare-messsages-from-api')
 const contextPath = '/manage-prototype'
 const sessionInfoFile = path.join(tmpDir, 'auth-sessions.json')
 
@@ -93,7 +95,7 @@ async function lookupHostingConfig () {
   const url = `${getConfig().nowPrototypeItAPIBaseUrl}/v1/hosting-config-for-nowprototypeit/${encodeURIComponent(kitVersion)}`
   const defaultFailure = {
     isCompatible: false,
-    messageHtml: 'Failed to load, please make sure you have a reliable internet connection.'
+    messageFormattedText: 'Failed to load, please make sure you have a reliable internet connection.'
   }
   try {
     const response = await standardJsonGetRequest(url)
@@ -123,7 +125,7 @@ module.exports = {
       if (!hostingConfig.isCompatible) {
         return res.render('hosting-error', {
           headerSubNavItems: getPageNavLinks(req),
-          messageHtml: hostingConfig.messageHtml
+          message: prepareMessageFromApiAsHtml(hostingConfig.messageFormattedText)
         })
       }
       const originalUrl = req.originalUrl.split('?')[0]

--- a/lib/dev-server/manage-prototype/utils/prepare-messages-from-api.spec.js
+++ b/lib/dev-server/manage-prototype/utils/prepare-messages-from-api.spec.js
@@ -11,13 +11,13 @@ describe('prepareMessagesFromApi', () => {
         version: '0.0.0',
         upgradeAvailable: true,
         messages: [
-          'This is **bold**, *italic*, and a (link:/link). Links have to contain **the same** *URL* and *innerText*, this is to *protect* against malicious data coming from the server which **we do not expect**, but it would be *naive* to ignore the possibility. Find out more by reading about defence in depth (link:https://en.wikipedia.org/wiki/Defence_in_depth)',
+          'This is **bold**, *italic*, and a (link:/link). Links have to contain **the same** *URL* and *innerText*, this is to *protect* against malicious data coming from the server which **we do not expect**, but it would be *naive* to ignore the possibility. Find out more by reading about defence in depth (link:https://en.wikipedia.org/wiki/Defense_in_depth_(computing))',
           'Plain text messages are just treated as plain text.',
           'Three ***asterisks*** produces some not ideal, but acceptable behaviour.'
         ]
       })).toEqual([
         { html: '<a href="/manage-prototype/plugin/npm:nowprototypeit">An update is available, you can now install that directly from the plugin page.</a>' },
-        { html: 'This is <strong>bold</strong>, <em>italic</em>, and a <a href="/link">/link</a>. Links have to contain <strong>the same</strong> <em>URL</em> and <em>innerText</em>, this is to <em>protect</em> against malicious data coming from the server which <strong>we do not expect</strong>, but it would be <em>naive</em> to ignore the possibility. Find out more by reading about defence in depth <a href="https://en.wikipedia.org/wiki/Defence_in_depth">https://en.wikipedia.org/wiki/Defence_in_depth</a>' },
+        { html: 'This is <strong>bold</strong>, <em>italic</em>, and a <a href="/link">/link</a>. Links have to contain <strong>the same</strong> <em>URL</em> and <em>innerText</em>, this is to <em>protect</em> against malicious data coming from the server which <strong>we do not expect</strong>, but it would be <em>naive</em> to ignore the possibility. Find out more by reading about defence in depth <a href="https://en.wikipedia.org/wiki/Defense_in_depth_(computing)">https://en.wikipedia.org/wiki/Defense_in_depth_(computing)</a>' },
         { html: 'Plain text messages are just treated as plain text.' },
         { html: 'Three *<strong>asterisks</strong>* produces some not ideal, but acceptable behaviour.' }
       ])

--- a/lib/dev-server/manage-prototype/utils/prepare-messages-from-api.spec.js
+++ b/lib/dev-server/manage-prototype/utils/prepare-messages-from-api.spec.js
@@ -1,0 +1,101 @@
+const { prepareMessagesFromApi } = require('./prepare-messsages-from-api')
+
+function unchnagedInputInOutputFormat (input) {
+  return input.map(text => ({ html: text }))
+}
+
+describe('prepareMessagesFromApi', () => {
+  describe('documentation', () => {
+    it('should process bold, italic and links while adding the standard message for outdated kits', () => {
+      expect(prepareMessagesFromApi({
+        version: '0.0.0',
+        upgradeAvailable: true,
+        messages: [
+          'This is **bold**, *italic*, and a (link:/link). Links have to contain **the same** *URL* and *innerText*, this is to *protect* against malicious data coming from the server which **we do not expect**, but it would be *naive* to ignore the possibility. Find out more by reading about defence in depth (link:https://en.wikipedia.org/wiki/Defence_in_depth)',
+          'Plain text messages are just treated as plain text.',
+          'Three ***asterisks*** produces some not ideal, but acceptable behaviour.'
+        ]
+      })).toEqual([
+        { html: '<a href="/manage-prototype/plugin/npm:nowprototypeit">An update is available, you can now install that directly from the plugin page.</a>' },
+        { html: 'This is <strong>bold</strong>, <em>italic</em>, and a <a href="/link">/link</a>. Links have to contain <strong>the same</strong> <em>URL</em> and <em>innerText</em>, this is to <em>protect</em> against malicious data coming from the server which <strong>we do not expect</strong>, but it would be <em>naive</em> to ignore the possibility. Find out more by reading about defence in depth <a href="https://en.wikipedia.org/wiki/Defence_in_depth">https://en.wikipedia.org/wiki/Defence_in_depth</a>' },
+        { html: 'Plain text messages are just treated as plain text.' },
+        { html: 'Three *<strong>asterisks</strong>* produces some not ideal, but acceptable behaviour.' }
+      ])
+    })
+  })
+  it('should pass on basic valuse', () => {
+    expect(prepareMessagesFromApi({
+      version: '0.0.0',
+      upgradeAvailable: false,
+      messages: ['hello']
+    })).toEqual([{ html: 'hello' }])
+  })
+  it('should pass on html', () => {
+    expect(prepareMessagesFromApi({
+      version: '0.0.0',
+      upgradeAvailable: false,
+      messages: ['<script>alert("hello world")</script>']
+    })).toEqual([{ html: '&lt;script&gt;alert("hello world")&lt;/script&gt;' }])
+  })
+  it('should format bold text', () => {
+    expect(prepareMessagesFromApi({
+      version: '0.0.0',
+      upgradeAvailable: false,
+      messages: ['Hello **there**']
+    })).toEqual([{ html: 'Hello <strong>there</strong>' }])
+  })
+  it('should not recognise double asterisks disconnected from words', () => {
+    const input = ['Hello ** there**', 'Hello ** there **', 'Hello **there **']
+    expect(prepareMessagesFromApi({
+      version: '0.0.0',
+      upgradeAvailable: false,
+      messages: [...input]
+    })).toEqual(unchnagedInputInOutputFormat(input))
+  })
+  it('should format italic text', () => {
+    expect(prepareMessagesFromApi({
+      version: '0.0.0',
+      upgradeAvailable: false,
+      messages: ['Hello *there*']
+    })).toEqual([{ html: 'Hello <em>there</em>' }])
+  })
+  it('should not recognise single asterisks disconnected from words', () => {
+    const input = ['Hello * there*', 'Hello * there *', 'Hello *there *', 'Some* information about a* product']
+    expect(prepareMessagesFromApi({
+      version: '0.0.0',
+      upgradeAvailable: false,
+      messages: input
+    })).toEqual(unchnagedInputInOutputFormat(input))
+  })
+  it('should format links', () => {
+    expect(prepareMessagesFromApi({
+      version: '0.0.0',
+      upgradeAvailable: false,
+      messages: ['You really need to see this cat (link:https://docs.nowprototype.it/latest/test-helpers/cat?typeOfCat=housecat&quality=high). I hope that improved your day.']
+    })).toEqual([{ html: 'You really need to see this cat <a href="https://docs.nowprototype.it/latest/test-helpers/cat?typeOfCat=housecat&quality=high">https://docs.nowprototype.it/latest/test-helpers/cat?typeOfCat=housecat&quality=high</a>. I hope that improved your day.' }])
+  })
+  it('should not recognise single asterisks disconnected from words', () => {
+    const input = [
+      'You really need to see this cat ( link:https://docs.nowprototype.it/latest/test-helpers/cat?typeOfCat=housecat&quality=high). I hope that improved your day.',
+      'You really need to see this cat (link: https://docs.nowprototype.it/latest/test-helpers/cat?typeOfCat=housecat&quality=high). I hope that improved your day.',
+      'You really need to see this cat (link:https://docs.nowprototype.it/latest/test-helpers/cat?typeOfCat=housecat&quality=high ). I hope that improved your day.',
+      'You really need to see this cat (link:https://docs.no"wprototype.it/latest/test-helpers/cat?typeOfCat=housecat&quality=high ). I hope that improved your day.',
+      'You really need to see this cat (link:). I hope that improved your day.',
+      'You really need to see this cat (link:abc def). I hope that improved your day.'
+    ]
+    expect(prepareMessagesFromApi({
+      version: '0.0.0',
+      upgradeAvailable: false,
+      messages: input
+    })).toEqual(unchnagedInputInOutputFormat(input))
+  })
+  it('should add the standard update message', () => {
+    expect(prepareMessagesFromApi({
+      version: '0.0.0',
+      upgradeAvailable: true,
+      messages: []
+    })).toEqual([
+      { html: '<a href="/manage-prototype/plugin/npm:nowprototypeit">An update is available, you can now install that directly from the plugin page.</a>' }
+    ])
+  })
+})

--- a/lib/dev-server/manage-prototype/utils/prepare-messsages-from-api.js
+++ b/lib/dev-server/manage-prototype/utils/prepare-messsages-from-api.js
@@ -5,16 +5,23 @@ const chained = chainFns(
   addLinks
 )
 
-module.exports = {
-  prepareMessagesFromApi: function (messageResponse) {
-    const staticMessages = []
-    if (messageResponse.upgradeAvailable) {
-      staticMessages.push({
-        html: '<a href="/manage-prototype/plugin/npm:nowprototypeit">An update is available, you can now install that directly from the plugin page.</a>'
-      })
-    }
-    return [...staticMessages].concat(messageResponse.messages.map(text => ({ html: chained(text) })))
+function prepareMessagesFromApi (messageResponse) {
+  const staticMessages = []
+  if (messageResponse.upgradeAvailable) {
+    staticMessages.push({
+      html: '<a href="/manage-prototype/plugin/npm:nowprototypeit">An update is available, you can now install that directly from the plugin page.</a>'
+    })
   }
+  return [...staticMessages].concat(messageResponse.messages.map(prepareMessageFromApiAsHtml))
+}
+
+function prepareMessageFromApiAsHtml (text) {
+  return { html: chained(text) }
+}
+
+module.exports = {
+  prepareMessagesFromApi,
+  prepareMessageFromApiAsHtml
 }
 
 function chainFns (...fns) {

--- a/lib/dev-server/manage-prototype/utils/prepare-messsages-from-api.js
+++ b/lib/dev-server/manage-prototype/utils/prepare-messsages-from-api.js
@@ -1,0 +1,40 @@
+const chained = chainFns(
+  stripHtmlTags,
+  addBoldTags,
+  addItalicTags,
+  addLinks
+)
+
+module.exports = {
+  prepareMessagesFromApi: function (messageResponse) {
+    const staticMessages = []
+    if (messageResponse.upgradeAvailable) {
+      staticMessages.push({
+        html: '<a href="/manage-prototype/plugin/npm:nowprototypeit">An update is available, you can now install that directly from the plugin page.</a>'
+      })
+    }
+    return [...staticMessages].concat(messageResponse.messages.map(text => ({ html: chained(text) })))
+  }
+}
+
+function chainFns (...fns) {
+  return function (text) {
+    return fns.reduce((acc, fn) => fn(acc), text)
+  }
+}
+
+function addBoldTags (text) {
+  return text.replaceAll(/\*\*(\w.*?\w)\*\*/g, '<strong>$1</strong>')
+}
+
+function addItalicTags (text) {
+  return text.replaceAll(/\*(\w.*?(\w))\*/g, '<em>$1</em>')
+}
+
+function addLinks (text) {
+  return text.replaceAll(/\(link:([^ ]+)\)/g, '<a href="$1">$1</a>')
+}
+
+function stripHtmlTags (text) {
+  return text.replaceAll('<', '&lt;').replaceAll('>', '&gt;')
+}

--- a/lib/dev-server/manage-prototype/views/hosting-error.njk
+++ b/lib/dev-server/manage-prototype/views/hosting-error.njk
@@ -13,8 +13,8 @@
     There was an error while communicating with the hosting platform
   </h1>
 
-  {% if messageHtml %}
-    {{ messageHtml | safe }}
+  {% if message.html %}
+    <p>{{ message.html | safe }}</p>
   {% endif %}
 
   <p><a href="/manage-prototype">Back to Manage Your Prototype</a></p>

--- a/lib/dev-server/manage-prototype/views/hosting-logged-out.njk
+++ b/lib/dev-server/manage-prototype/views/hosting-logged-out.njk
@@ -25,7 +25,7 @@
   <p>To start hosting you'll need to log in to your nowprototype.it account.</p>
 
   {% if loggedOutMessage %}
-    <p>{{ loggedOutMessage | safe }}</p>
+    {{ loggedOutMessage | safe }}
   {% endif %}
   {% if errorSplash %}
     {{ nowPrototypeItError({

--- a/lib/dev-server/manage-prototype/views/index.njk
+++ b/lib/dev-server/manage-prototype/views/index.njk
@@ -23,13 +23,7 @@
     <ul class="nowprototypeit-manage-prototype-messages nowprototypeit-bullet-list">
       {% for message in messages %}
         <li class="nowprototypeit-manage-prototype-messages__item">
-          {% if message.html %}
-            {{ message.html | safe }}
-          {% elseif message.url %}
-            <a href="{{ message.url }}">{{ message.text }}</a>
-          {% else %}
-            {{ message.text }}
-          {% endif %}
+          {{ message.html | safe }}
         </li>
       {% endfor %}
     </ul>

--- a/lib/dev-server/watch/prototypeStyles.js
+++ b/lib/dev-server/watch/prototypeStyles.js
@@ -24,7 +24,3 @@ async function setup () {
 module.exports = {
   setup
 }
-
-setInterval(() => {
-  verboseLog('SASS change watcher still running.')
-}, 1000)

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -347,7 +347,7 @@ function fork (command, options) {
       return await ipcClose({ skipForkCloseEvent })
     }
     verboseLog('Forked process is not IPC, using non IPC close', command, pid)
-    return nonIpcClose({ skipForkCloseEvent })
+    return await nonIpcClose({ skipForkCloseEvent })
   }
   const simpleCloseHandler = async () => {
     await close()


### PR DESCRIPTION
The messages from the API was [broken in release 0.10.0](https://github.com/nowprototypeit/nowprototypeit/compare/v0.9.5...v0.10.0#diff-d5109920b34c2b2e141bd41232d8876432a17479c388e142d8a036bb7b36ea62L94-L105) and we didn't have a test for it. 

We have now introduced a fake API into the tests in order to cover behaviour which relies on the API.

These messages are intended to encourage users to keep their Now Prototype It version up-to-date and to inform them if any issues become known about earlier versions - including security issues and incompatabilities.

This PR introduces a basic rich-text format to replace the old plain text messages and raw HTML on the hosting page.  This new format avoids accepting HTML that could be used in an attack - importantly any link that is included shows the URL in the text and there's no built-in mechanism to override that.