### PR TITLE
Added userInput view variable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+- Introduced a `userInput` variable which can be used to access user input from forms.  This is a variable that was previously known as `data` in the GOV.UK Prototype Kit, we plan to phase that out over a long period of time.  The addition of `userInput` allows us to add this to our documentation so that new users get used to that while existing users can continue to use `data` for the time being.
+
 ### Fixes
 
  - The messages from the API was [broken in release 0.10.0](https://github.com/nowprototypeit/nowprototypeit/compare/v0.9.5...v0.10.0#diff-d5109920b34c2b2e141bd41232d8876432a17479c388e142d8a036bb7b36ea62L94-L105) and we didn't have a test for it.  We have now introduced a fake API into the tests in order to cover behaviour which relies on the API.  These messages are intended to encourage users to keep their Now Prototype It version up-to-date and to inform them if any issues become known about earlier versions - including security issues and incompatabilities.

--- a/features/fixtures/nunjucks/form-receiver-legacy.njk
+++ b/features/fixtures/nunjucks/form-receiver-legacy.njk
@@ -2,6 +2,6 @@
 <html>
 <head><title>Basic form example</title></head>
 <body>
-<h1>You entered: {{ userInput.example }}</h1>
+<h1>You entered: {{ data.example }}</h1>
 </body>
 </html>

--- a/features/manage-prototype/hosting.feature
+++ b/features/manage-prototype/hosting.feature
@@ -61,6 +61,6 @@ Scenario: Incompatible version with a different message
     Then the main heading should be updated to "You're in the process of logging in"
     When I enter the one-time-password as "1234" in the fake website popup window
     Then the popup window should be closed
-    And the main heading should read "Upload your prototype to Now Prototype It's hosting platform"
+    And the main heading should be updated to "Upload your prototype to Now Prototype It's hosting platform"
     And the page should include a paragraph that reads "You can upload 1 more prototype. If this isn't enough please visit your profile on the Now Prototype It website where you can remove unused prototypes or increase your limit."
     And the username on the page should be "nowprototypeit"

--- a/features/user-content/forms.feature
+++ b/features/user-content/forms.feature
@@ -23,3 +23,15 @@ Feature: Forms
     And I submit the form
     And I visit "/form-receiver"
     Then the main heading should be updated to "You entered: This is from a post"
+
+  @no-variant
+  Scenario: Legacy data variable working the same as userInput variable
+    Given I create a file "app/views/form.html" based on the fixture file "html/form-with-post-action.html"
+    And I create a file "app/views/form-receiver.html" based on the fixture file "nunjucks/form-receiver-legacy.njk"
+    And I visit "/form-receiver"
+    And the main heading should be updated to "You entered:"
+    When I visit "/form"
+    And I enter "This is from a post" into the "example" field
+    And I submit the form
+    And I visit "/form-receiver"
+    Then the main heading should be updated to "You entered: This is from a post"

--- a/lib/session.js
+++ b/lib/session.js
@@ -99,25 +99,24 @@ const sessionDataDefaults = loadSessionDataDefaults()
 // Middleware - store any data sent in session, and pass it to all views
 
 function autoStoreData (req, res, next) {
-  if (!req.session.data) {
-    req.session.data = {}
-  }
-  res.locals.data = {}
+  res.locals.data = res.locals.userInput = {}
+  req.session.userInput = req.session.data = { ...(req.session.data || {}), ...(req.session.userInput || {}) }
 
   if (req.originalUrl.startsWith('/manage-prototype/')) {
     next()
     return
   }
 
-  req.session.data = Object.assign({}, sessionDataDefaults, req.session.data)
+  req.session.userInput = Object.assign({}, sessionDataDefaults, req.session.userInput)
 
-  storeData(req.body, req.session.data)
-  storeData(req.query, req.session.data)
+  storeData(req.body, req.session.userInput)
+  storeData(req.query, req.session.userInput)
 
   // Send session data to all views
 
-  for (const j in req.session.data) {
-    res.locals.data[j] = req.session.data[j]
+  for (const j in req.session.userInput) {
+    res.locals.userInput[j] = req.session.userInput[j]
+    req.session.data[j] = req.session.userInput[j]
   }
 
   next()

--- a/lib/session.test.js
+++ b/lib/session.test.js
@@ -50,23 +50,27 @@ describe('checked', () => {
 })
 
 describe('autoStoreData', () => {
-  const req = {
-    session: {}
-  }
-  const res = { }
+  let testScope
 
   beforeEach(() => {
-    req.body = {}
-    req.query = {}
-    req.originalUrl = '/'
-    req.session.data = {
+    testScope = {
+      req: {
+        session: {}
+      },
+      res: {}
+    }
+
+    testScope.req.body = {}
+    testScope.req.query = {}
+    testScope.req.originalUrl = '/'
+    testScope.req.session.userInput = {
       existingData: 'existing data'
     }
-    res.locals = {}
+    testScope.res.locals = {}
   })
 
   it('strips all properties where the name is prefixed with an underscore when saving the request query to the session and locals data', () => {
-    req.query = {
+    testScope.req.query = {
       _omitMe: 'omit me',
       doIncludeMe: 'include me'
     }
@@ -74,14 +78,16 @@ describe('autoStoreData', () => {
       doIncludeMe: 'include me',
       existingData: 'existing data'
     }
-    sessionUtils.autoStoreData(req, res, () => {
-      expect(res.locals.data).toEqual(expectedData)
-      expect(req.session.data).toEqual(expectedData)
+    sessionUtils.autoStoreData(testScope.req, testScope.res, () => {
+      expect(testScope.res.locals.userInput).toEqual(expectedData)
+      expect(testScope.req.session.userInput).toEqual(expectedData)
+      expect(testScope.res.locals.data).toEqual(expectedData)
+      expect(testScope.req.session.data).toEqual(expectedData)
     })
   })
 
   it('removes all occurrences of the value "_unchecked" in checkboxes when saving the request body to the session and locals data', () => {
-    req.body = {
+    testScope.req.body = {
       checkBoxes1: ['_unchecked', 'cb1-1', '_unchecked', '_unchecked', 'cb1-2', '_unchecked'],
       checkBoxes2: ['_unchecked', '_unchecked'],
       checkBoxes3: ['cb3-1', 'cb3-2'],
@@ -93,25 +99,29 @@ describe('autoStoreData', () => {
       checkBoxes3: ['cb3-1', 'cb3-2'],
       existingData: 'existing data'
     }
-    sessionUtils.autoStoreData(req, res, () => {
-      expect(res.locals.data).toEqual(expectedData)
-      expect(req.session.data).toEqual(expectedData)
+    sessionUtils.autoStoreData(testScope.req, testScope.res, () => {
+      expect(testScope.res.locals.userInput).toEqual(expectedData)
+      expect(testScope.req.session.userInput).toEqual(expectedData)
+      expect(testScope.res.locals.data).toEqual(expectedData)
+      expect(testScope.req.session.data).toEqual(expectedData)
     })
   })
 
   it('should do nothing when on a manage-prototype page', () => {
-    req.originalUrl = '/manage-prototype/plugins'
+    testScope.req.originalUrl = '/manage-prototype/plugins'
 
-    req.body = {
+    testScope.req.body = {
       checkBoxes1: ['_unchecked', 'cb1-1', '_unchecked', '_unchecked', 'cb1-2', '_unchecked'],
       checkBoxes2: ['_unchecked', '_unchecked'],
       checkBoxes3: ['cb3-1', 'cb3-2'],
       existingData: 'existing data'
     }
 
-    sessionUtils.autoStoreData(req, res, () => {
-      expect(res.locals.data).toEqual({})
-      expect(req.session.data).toEqual({ existingData: 'existing data' })
+    sessionUtils.autoStoreData(testScope.req, testScope.res, () => {
+      expect(testScope.res.locals.userInput).toEqual({})
+      expect(testScope.req.session.userInput).toEqual({ existingData: 'existing data' })
+      expect(testScope.res.locals.data).toEqual({})
+      expect(testScope.req.session.data).toEqual({ existingData: 'existing data' })
     })
   })
 })


### PR DESCRIPTION
We're moving towards using a `userInput` variable which can be used to access user input from forms.

This is a variable that was previously known as `data` in the GOV.UK Prototype Kit, we plan to phase that out over a long period of time.

The addition of `userInput` allows us to add this to our documentation so that new users get used to that while existing users can continue to use `data` for the time being.