### PR TITLE
Storing form state when auto-refreshing pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Features
 
+- Form inputs now keep their values when the page is auto-refreshed.  We were already maintaining your scroll position, now if you're halfway through completing a form and realise a change you want to make, you can make that change and carry on as you were.
 - Updating Node.js supported versions, we are now in line with the versions Node.js themselves support.  v20, v22, v24.  We do support older versions with limited functionality. We're still testing Node 18 but we will drop full support for that if supporting it becomes a burden. We recommend using Node 24 for your prototypes.
 - Introduced a `userInput` variable which can be used to access user input from forms.  This is a variable that was previously known as `data` in the GOV.UK Prototype Kit, we plan to phase that out over a long period of time.  The addition of `userInput` allows us to add this to our documentation so that new users get used to that while existing users can continue to use `data` for the time being.
 

--- a/features/editing/auto-refresh.feature
+++ b/features/editing/auto-refresh.feature
@@ -1,0 +1,26 @@
+@nunjucks
+@auto-refresh
+@no-variant
+Feature: Nunjucks editing
+
+  Scenario: Keeping state when auto-refreshing
+    Given I create a file "app/views/example.njk" based on the fixture file "nunjucks/complex-form.njk"
+    And I visit "/example"
+    And the main heading should be updated to "State info"
+    And I submit the form
+    Then the page should include a paragraph that reads "text:"
+    Then the page should include a paragraph that reads "checkboxes: empty"
+    Then the page should include a paragraph that reads "radio: empty"
+    When I enter "Some text" into the "text" field
+    And I select the "abc" checkbox
+    And I select the "def" checkbox
+    And I select the "pqr" radio button
+    When I append the file "app/views/example.njk" with contents "<p>Triggering refresh 1</p>"
+    Then the page should include a paragraph that reads "Triggering refresh 1"
+    Then the page should include a paragraph that reads "text:"
+    Then the page should include a paragraph that reads "checkboxes: empty"
+    Then the page should include a paragraph that reads "radio: empty"
+    When I click the button with text "Submit"
+    Then the page should include a paragraph that reads "text: Some text"
+    And the page should include a paragraph that reads "checkboxes: abc, def"
+    And the page should include a paragraph that reads "radio: pqr"

--- a/features/fixtures/nunjucks/complex-form.njk
+++ b/features/fixtures/nunjucks/complex-form.njk
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+
+<h1>State info</h1>
+<h2>Current state</h2>
+<p>text: {{ userInput.text | default("empty") }}</p>
+<p>checkboxes: {% for value in (userInput.checkboxes | default(["empty"])) %}{% if loop.index > 1 %}, {% endif %}{{ value }}{% endfor %}</p>
+<p>radio: {{ userInput.radio | default("empty") }}</p>
+
+<form method="post">
+  <label for="text">Text input</label>
+  <input type="text" id="text" name="text" value="{{ userInput.text }}">
+
+  <fieldset>
+    <legend>Checkboxes</legend>
+    <label>
+      <input type="checkbox" name="checkboxes" id="abc" value="abc" {% if 'abc' in (userInput.checkboxes | default([])) %}checked{% endif %}>
+      ABC
+    </label>
+    <label>
+      <input type="checkbox" name="checkboxes" id="def" value="def" {% if 'def' in (userInput.checkboxes | default([])) %}checked{% endif %}>
+      DEF
+    </label>
+    <label>
+      <input type="checkbox" name="checkboxes" id="ghi" value="ghi" {% if 'ghi' in (userInput.checkboxes | default([])) %}checked{% endif %}>
+      GHI
+    </label>
+  </fieldset>
+
+  <fieldset>
+    <legend>Radio buttons</legend>
+    <label>
+      <input type="radio" name="radio" value="jkl" id="jkl" {% if userInput.radio == 'jkl' %}checked{% endif %}>
+      JKL
+    </label>
+    <label>
+      <input type="radio" name="radio" value="mno" id="mno" {% if userInput.radio == 'mno' %}checked{% endif %}>
+      MNO
+    </label>
+    <label>
+      <input type="radio" name="radio" value="pqr" id="pqr" {% if userInput.radio == 'pqr' %}checked{% endif %}>
+      PQR
+    </label>
+  </fieldset>
+
+  <button type="submit">Submit</button>
+</form>

--- a/features/routers/routers-from-plugins.feature
+++ b/features/routers/routers-from-plugins.feature
@@ -1,20 +1,20 @@
 @plugin-routers
 Feature: Routers from plugins
 
-  @auto-refresh-off
   @no-variant
   Scenario: MPJ Info pages - read more
     Given I have the demo plugin "marsha-p-johnson" installed
+    And I wait for 1 seconds
     When I visit "/plugin-routes/marsha-p-johnson/info/1"
     Then the main heading should be updated to "Step one"
     When I select the "know-more-yes" radio button
     And I submit the form
     Then the main heading should be updated to "Step two"
 
-  @auto-refresh-off
   @no-variant
   Scenario: MPJ Info pages - End early
     Given I have the demo plugin "marsha-p-johnson" installed
+    And I wait for 1 seconds
     When I visit "/plugin-routes/marsha-p-johnson/info/1"
     Then the main heading should be updated to "Step one"
     When I select the "know-more-no" radio button

--- a/features/step-definitions/general.steps.js
+++ b/features/step-definitions/general.steps.js
@@ -35,10 +35,13 @@ Then('the main heading should read {string}', standardTimeout, async function (e
 })
 
 Then('the page should include a paragraph that reads {string}', standardTimeout, async function (expectedHeading) {
-  const allPText = (await this.browser.getTextFromSelectorAll('p')).map(standardSpaces)
-  if (!allPText.includes(expectedHeading)) {
-    throw new Error(`Expected to find paragraph with text [${expectedHeading}] but found [${allPText.join(', ')}]`)
-  }
+  await waitForConditionToBeMet(standardTimeout, async () => {
+    const allPText = (await this.browser.getTextFromSelectorAll('p')).map(standardSpaces)
+    if (!allPText.includes(expectedHeading)) {
+      throw new Error(`Expected to find paragraph with text [${expectedHeading}] but found [${allPText.join(', ')}]`)
+    }
+    return true
+  })
   function standardSpaces (text) {
     return text.replace(/\s+/g, ' ').trim()
   }
@@ -174,6 +177,10 @@ When('I submit the form', standardTimeout, async function () {
 
 When('I submit the form with ID {string}', standardTimeout, async function (formId) {
   await this.browser.submitFormBySelector(`#${formId}`, standardTimeout)
+})
+
+When('I select the {string} checkbox', standardTimeout, async function (checkboxElementId) {
+  await this.browser.selectCheckboxById(checkboxElementId)
 })
 
 When('I select the {string} radio button', standardTimeout, async function (radioElementId) {

--- a/features/step-definitions/setup-helpers/browser.js
+++ b/features/step-definitions/setup-helpers/browser.js
@@ -3,7 +3,7 @@ const uuid = require('uuid')
 const { standardTimeout } = require('./timeouts')
 const { addShutdownFn } = require('../../../lib/utils/shutdownHandlers')
 const { verboseLog } = require('../../../lib/utils/verboseLogger')
-const { retryableErrorLog } = process.env.NPI_TEST__LOG_RETRIABLE_ERRORS === 'true' ? console.log : () => {}
+const retryableErrorLog = process.env.NPI_TEST__LOG_RETRIABLE_ERRORS === 'true' ? console.log : () => {}
 
 let singleSharedBrowser = null
 

--- a/lib/dev-server/manage-prototype/assets/scripts/reloader-client.js
+++ b/lib/dev-server/manage-prototype/assets/scripts/reloader-client.js
@@ -7,13 +7,46 @@
     lastReload = Date.now()
   }
 
-  const scrollTo = window.localStorage.getItem('nowprotoypeit-scroll-after-reload')
+  const scrollKey = 'nowprotoypeit-scroll-after-reload'
+  const fieldsKey = 'nowprotoypeit-fields-after-reload'
+  const scrollTo = window.localStorage.getItem(scrollKey)
   if (scrollTo) {
     document.addEventListener('DOMContentLoaded', () => {
       window.scrollTo(0, parseInt(scrollTo, 10))
     })
   }
-  window.localStorage.removeItem('nowprotoypeit-scroll-after-reload')
+  const fields = window.localStorage.getItem(fieldsKey)
+  if (fields) {
+    try {
+      const parsedFields = JSON.parse(fields)
+      const simple = parsedFields?.simple || {}
+      Object.keys(simple).forEach((key) => {
+        const fields = document.querySelectorAll(`[name="${key}"]`)
+        fields.forEach((field) => {
+          if (field && field.type !== 'checkbox' && field.type !== 'radio') {
+            field.value = simple[key]?.shift() || ''
+          }
+        })
+      })
+      const checked = parsedFields?.checked || {}
+      Object.keys(checked).forEach((key) => {
+        const arr = checked[key]
+        while (arr.length > 0) {
+          const value = arr.shift()
+          const fields = document.querySelectorAll(`[name="${key}"][value="${value}"]`)
+          fields.forEach((field) => {
+            if (field.type === 'checkbox' || field.type === 'radio') {
+              field.checked = true
+            }
+          })
+        }
+      })
+    } catch (e) {
+      console.error('Failed to parse fields from localStorage:', e)
+    }
+  }
+  window.localStorage.removeItem(scrollKey)
+  window.localStorage.removeItem(fieldsKey)
   let repeatFailureCount = 0
 
   function checkForReload () {
@@ -21,7 +54,25 @@
       .then((response) => {
         response.json().then(json => {
           if (json.shouldReload) {
-            window.localStorage.setItem('nowprotoypeit-scroll-after-reload', window.scrollY)
+            window.localStorage.setItem(scrollKey, window.scrollY)
+            const fieldsStorageValue = JSON.stringify(
+              Array.from(document.querySelectorAll('input, select, textarea'))
+                .reduce((acc, field) => {
+                  if (field.name) {
+                    if (field.type === 'checkbox' || field.type === 'radio') {
+                      const current = acc.checked[field.name] = acc.checked[field.name] || []
+                      if (field.checked) {
+                        current.push(field.value)
+                      }
+                    } else {
+                      const current = acc.simple[field.name] = acc.simple[field.name] || []
+                      current.push(field.value)
+                    }
+                  }
+                  return acc
+                }, { simple: {}, checked: {} })
+            )
+            window.localStorage.setItem(fieldsKey, fieldsStorageValue)
             window.location.reload()
           } else {
             setTimeout(checkForReload, json.nextCheckInMilliseconds || 1000)


### PR DESCRIPTION
Form inputs now keep their values when the page is auto-refreshed.  We were already maintaining your scroll position, now if you're halfway through completing a form and realise a change you want to make, you can make that change and carry on as you were.

The timing was inspired by the workaround needed in the tests after the Node 24.  I thought this change would fix the plugin router tests but it doesn't.  I dislike adding a set delay but I've chosen that as it's preferable to turning off features when the speed of the test seems to be the reason for the failure.