### PR TITLE
Properly clearing session under both the old name and the new name.

### DIFF
--- a/features/step-definitions/general.steps.js
+++ b/features/step-definitions/general.steps.js
@@ -269,3 +269,8 @@ Then('the page should contain a link with URL and text of {string}', standardTim
     throw new Error(`Expected link text to be the same as the URL, but found text [${found.text}] and url [${found.url}]`)
   }
 })
+
+When('I clear my session data', standardTimeout, async function () {
+  await this.browser.openUrl('/manage-prototype/clear-data')
+  await this.browser.clickButtonWithText('Clear session data')
+})

--- a/features/user-content/forms.feature
+++ b/features/user-content/forms.feature
@@ -35,3 +35,6 @@ Feature: Forms
     And I submit the form
     And I visit "/form-receiver"
     Then the main heading should be updated to "You entered: This is from a post"
+    When I clear my session data
+    And I visit "/form-receiver"
+    And the main heading should be updated to "You entered:"

--- a/server.js
+++ b/server.js
@@ -245,7 +245,7 @@ app.get('/manage-prototype/clear-data', function (req, res) {
 })
 
 app.post('/manage-prototype/clear-data', function (req, res) {
-  req.session.data = {}
+  req.session.data = req.session.userInput = {}
   res.render('prototype-core/views/clear-data.njk', {
     ...req.app.locals,
     stage: 'completed',


### PR DESCRIPTION
The issue was introduced in https://github.com/nowprototypeit/nowprototypeit/pull/90 and caught before releasing.