### PR TITLE
Providing the ability to lookup plugin-specific config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Form inputs now keep their values when the page is auto-refreshed.  We were already maintaining your scroll position, now if you're halfway through completing a form and realise a change you want to make, you can make that change and carry on as you were.
 - Updating Node.js supported versions, we are now in line with the versions Node.js themselves support.  v20, v22, v24.  We do support older versions with limited functionality. We're still testing Node 18 but we will drop full support for that if supporting it becomes a burden. We recommend using Node 24 for your prototypes.
 - Introduced a `userInput` variable which can be used to access user input from forms.  This is a variable that was previously known as `data` in the GOV.UK Prototype Kit, we plan to phase that out over a long period of time.  The addition of `userInput` allows us to add this to our documentation so that new users get used to that while existing users can continue to use `data` for the time being.
+- Plugin-specific settings are now available via `require('nowprototypeit').config.getPluginSpecificConfig('the-plugin-name')`, this is inspired by the need for a govuk-rebrand setting and can be used any time a plugin-specific setting is needed in the Node layer e.g. routers and Nunjucks Filters/Functions.
 
 ### Fixes
 

--- a/LICENCE.txt
+++ b/LICENCE.txt
@@ -1,13 +1,13 @@
-The MIT License
+MIT License
 
-Copyright (C) 2014 Crown Copyright (Government Digital Service)
+Copyright (c) 2025 Now Prototype It Limited
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-of the Software, and to permit persons to whom the Software is furnished to do
-so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.

--- a/features/fixtures/nunjucks/filter-fron-settings-example.njk
+++ b/features/fixtures/nunjucks/filter-fron-settings-example.njk
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+
+<h1>{{ "This heading goes through a filter" | caseBasedOnSettings }}</h1>

--- a/features/fixtures/plugins/marsha-p-johnson/filters.js
+++ b/features/fixtures/plugins/marsha-p-johnson/filters.js
@@ -1,0 +1,12 @@
+try {
+  const { addFilter } = require('nowprototypeit').views
+  const { getPluginSpecificConfig } = require('nowprototypeit').config
+
+  const uppercaseTitles = getPluginSpecificConfig('marsha-p-johnson').upperCaseTitles
+
+  console.log('got upper case titles from config: ', uppercaseTitles)
+
+  addFilter('caseBasedOnSettings', (input) => uppercaseTitles ? input.toUpperCase() : input)
+} catch (e) {
+  console.log('error reading mpj config - this happens when Cucumber tries to load all the JS files before running the tests')
+}

--- a/features/fixtures/plugins/marsha-p-johnson/now-prototype-it.config.json
+++ b/features/fixtures/plugins/marsha-p-johnson/now-prototype-it.config.json
@@ -32,8 +32,21 @@
     "importNunjucksMacrosInto": [
       "/nunjucks/marsha-p-johnson/layouts/example-layout.njk"
     ],
+    "nunjucksFunctions": [
+      "/filters.js"
+    ],
     "expressRouters": [
       "/mpj-routes.js"
-    ]
+    ],
+    "settings": {
+      "value": false,
+      "isDefault": true,
+      "userInterface": {
+        "key": "upperCaseTitles",
+        "name": "Upper case titles",
+        "hintText": "This controls a filter which is used to turn titles uppercase (in specific situations).",
+        "type": "bool"
+      }
+    }
   }
 }

--- a/features/settings/plugin-settings.feature
+++ b/features/settings/plugin-settings.feature
@@ -21,3 +21,15 @@ Feature: Plugin settings
     Then I should see the settings saved message
     When I visit "/style-example"
     Then the first paragraph margin top should become "10px"
+
+  @mpj-variant
+  Scenario: Filters looking up settings
+    Given I create a file "app/views/filter-example.njk" based on the fixture file "nunjucks/filter-fron-settings-example.njk"
+    And I visit "/filter-example"
+    And the main heading should read "This heading goes through a filter"
+    When I am on the plugin settings page for the "Marsha P Johnson" plugin
+    And I turn on the "upperCaseTitles" setting
+    And I press "Save changes"
+    And I should see the settings saved message
+    And I visit "/filter-example"
+    Then the main heading should be updated to "THIS HEADING GOES THROUGH A FILTER"

--- a/features/step-definitions/settings.steps.js
+++ b/features/step-definitions/settings.steps.js
@@ -12,6 +12,11 @@ When('I turn off the {string} setting', mediumActionTimeout, async function (fie
   await browser.selectRadioButtonBySelector(`input[type=radio][name=${fieldName}][value=false]`)
 })
 
+When('I turn on the {string} setting', mediumActionTimeout, async function (fieldName) {
+  const browser = this.browser
+  await browser.selectRadioButtonBySelector(`input[type=radio][name=${fieldName}][value=true]`)
+})
+
 When('I press {string}', standardTimeout, async function (buttonText) {
   await this.browser.clickButtonWithText(buttonText)
 })

--- a/index.js
+++ b/index.js
@@ -2,11 +2,12 @@
 const filtersApi = require('./lib/filters/api').external
 const functionsApi = require('./lib/functions/api').external
 const routesApi = require('./lib/routes/api').external
-const percistenceApi = require('./lib/persistence/api').external
-const markdownRenderersApi = require('./lib/markdownRenderers/api').external
+const persistenceApi = require('./lib/persistence/api').external
+const configApi = require('./lib/config.js').external
 
 module.exports = {
   requests: routesApi,
-  views: { ...filtersApi, ...functionsApi, ...markdownRenderersApi },
-  persistence: percistenceApi
+  views: { ...filtersApi, ...functionsApi },
+  persistence: persistenceApi,
+  config: configApi
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -117,6 +117,11 @@ function getConfig (config, swallowError = true) {
 }
 
 module.exports = {
-  getConfig
+  getConfig,
+  external: {
+    getPluginSpecificConfig: (...args) => {
+      return getConfig().getPluginSpecificConfig(...args)
+    }
+  }
 }
 endPerformanceTimer('config setup', performanceTimer)

--- a/lib/utils/replace-require.js
+++ b/lib/utils/replace-require.js
@@ -5,8 +5,10 @@ module.exports = {
   replaceRequire: () => {
     const originalRequire = Module.prototype.require
     Module.prototype.require = function (modulePath) {
-      if (modulePath === 'govuk-prototype-kit') {
-        console.log('We replaced a require(\'govuk-prototype-kit\') with require(\'nowprototypeit\')')
+      if (modulePath === 'govuk-prototype-kit' || modulePath === 'nowprototypeit' || modulePath === 'prototype-core') {
+        if (modulePath === 'govuk-prototype-kit') {
+          console.log('We replaced a require(\'govuk-prototype-kit\') with require(\'nowprototypeit\')')
+        }
         return originalRequire.call(this, path.join(__dirname, '..', '..', 'index.js'))
       }
       if (modulePath === 'govuk-prototype-kit/lib/config.js') {


### PR DESCRIPTION
This can be used to control Nunjucks functions & filters with settings in the UI.

Also corrected the MIT license file - it needed updating when I forked the project but I didn't notice until now.

Also making it easier for locally installed plugins to use `require('nowprototypeit`)` and provided a `require('prototype-core')` which is intended to make it easier to provide plugins which work with forks of Now Prototype It.

Removed Markdown API variable as it wasn't actually adding any properties.