### PR TITLE
Checking the version as part of the PR process.

### DIFF
--- a/.github/workflows/all-tests.yaml
+++ b/.github/workflows/all-tests.yaml
@@ -8,9 +8,21 @@ on:
   pull_request:
 
 jobs:
+  check-version:
+    name: Check Version
+    runs-on: linux
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - run: npm run check:version
+
   lint:
     name: Lint
     runs-on: linux
+    needs: check-version
     steps:
       - uses: actions/checkout@v4
       - name: Install Node.js
@@ -103,6 +115,7 @@ jobs:
   performance:
     name: Performance
     runs-on: linux
+    needs: check-version
     steps:
       - uses: actions/checkout@v3
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "scripts": {
     "start": "echo 'This project cannot be started, in order to test this project please create a prototype kit using the cli.'",
     "build:destructive": "./scripts/build-destructive",
+    "check:version": "./scripts/ensure-version-is-correct.js",
     "lint": "standard . bin/cli scripts/create-prototype-and-run.js scripts/release",
     "lint:fix": "npm run lint -- --fix",
     "test:unit": "jest --detectOpenHandles lib bin",

--- a/scripts/ensure-version-is-correct.js
+++ b/scripts/ensure-version-is-correct.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+
+const fsp = require('node:fs').promises
+
+process.exitCode = 100; // Default exit code in case the logic fails
+
+(async () => {
+  const [latestVersionFromNpm, versionFromPackageJson] = await Promise.all([
+    fetch('https://registry.npmjs.org/nowprototypeit/latest').then(res => res.json()).then(json => json.version),
+    fsp.readFile('package.json', 'utf8').then(data => JSON.parse(data).version)
+  ])
+  console.log('NPM version:', latestVersionFromNpm)
+  console.log('package JSON version:', versionFromPackageJson)
+  if (latestVersionFromNpm !== versionFromPackageJson) {
+    console.error('')
+    console.error(`Version mismatch! Latest NPM version [${latestVersionFromNpm}] does not match package.json version [${versionFromPackageJson}].`)
+    console.error('We manage the project version as part of the release process, so any manual changes are problematic.')
+    console.error('This can also happen if the post-release PR isn\'t merged yet, which would create an unhelpful order in the history.')
+    console.error('')
+    process.exit(1)
+  } else {
+    console.log('Version is correct.')
+    process.exit(0)
+  }
+})()


### PR DESCRIPTION
The post-release PR hadn't been merged which puts the history in an awkward state.  This PR doesn't fix that, but it does prevent it from happening again.   This will also protect against manual updates to the version which would cause a problem for the release process.

The first test-run should fail because the version currently doesn't match, if it fails with the correct error output then the next step is to merge the last post-release PR (https://github.com/nowprototypeit/nowprototypeit/pull/94), rebase and try again.

The error output should be:

```
Version mismatch! Latest NPM version [0.13.0] does not match package.json version [0.12.0].
We manage the project version as part of the release process, so any manual changes are problematic.
This can also happen if the post-release PR isn't merged yet, which would create an unhelpful order in the history.
```

Process:

 - [x] It failed for the correct reason with a good error output
 - [x] It passes after the release-pr is merged and rebased onto this branch