### PR TITLE
Chokidar4 and NPM audit fix

### DIFF
--- a/lib/dev-server/watch/installAndUninstall.js
+++ b/lib/dev-server/watch/installAndUninstall.js
@@ -38,8 +38,8 @@ async function setup (debounce, registerCloseFn) {
   const debouncedEmitChange = debounce(emitChange, 1000)
   const debouncedListener = debounce(listener, 1000)
 
-  watch([packageJsonPath, packageJsonLockPath], { allowGlobs: true, registerCloseFn })
-    .on('change', async (filePath) => {
+  watch([packageJsonPath, packageJsonLockPath], { registerCloseFn })
+    .on('change', async () => {
       const lastDependencyUpdateTime = await getLatestDependencyUpdateTime()
       if (lastDependencyUpdateTime === latestActionedDependencyUpdateTime) {
         return

--- a/lib/dev-server/watch/localPlugins.js
+++ b/lib/dev-server/watch/localPlugins.js
@@ -1,9 +1,9 @@
-const chokidar = require('chokidar')
 const path = require('path')
 const fsp = require('node:fs').promises
 const events = require('../dev-server-events')
 const eventTypes = require('../dev-server-event-types')
 const { projectDir } = require('../../utils/paths')
+const { watch } = require('./utils')
 
 module.exports = { setup }
 
@@ -30,8 +30,9 @@ async function setup (debounce, registerCloseFn) {
     })
 
     if (lstat.isSymbolicLink()) {
-      const listener = chokidar.watch(path.join(pathToModule, '**', '*'), {
-        ignoreInitial: true
+      const listener = watch(pathToModule, {
+        recursive: true,
+        allFileExtensions: true
       })
         .on('all', async (event, path) => {
           if (path.endsWith('.js') || path.endsWith('.json')) {

--- a/lib/dev-server/watch/managementPages.js
+++ b/lib/dev-server/watch/managementPages.js
@@ -1,9 +1,9 @@
-const chokidar = require('chokidar')
 const path = require('node:path')
 const events = require('../dev-server-events')
 const eventTypes = require('../dev-server-event-types')
 const { generateManagePrototypeCssIfNecessary, kitDependencyIsInDevelopment } = require('../manage-prototype/build')
 const { projectDir } = require('../../utils/paths')
+const { watch } = require('./utils')
 
 module.exports = { setup }
 async function setup (debounce, registerCloseFn) {
@@ -14,10 +14,12 @@ async function setup (debounce, registerCloseFn) {
     events.emitExternal(eventTypes.TRIGGER_WATCHER_RESTART)
   })
   if (await kitDependencyIsInDevelopment()) {
-    const handler = chokidar.watch([
-      path.join(pathToModule, 'lib', 'dev-server', '**', '*')
+    const handler = watch([
+      path.join(pathToModule, 'lib', 'dev-server')
     ], {
-      ignoreInitial: true
+      ignoreInitial: true,
+      recursive: true,
+      allFileExtensions: true
     })
       .on('all', async (event, path) => {
         if (path.endsWith('.js')) {

--- a/lib/dev-server/watch/prototypeConfig.js
+++ b/lib/dev-server/watch/prototypeConfig.js
@@ -20,9 +20,7 @@ async function setup () {
       events.emitExternal(eventTypes.MANAGEMENT_RESTART)
     }
   }
-  watch(configPath, {
-    allowGlobs: false
-  })
+  watch(configPath, {})
     .on('add', handler)
     .on('change', handler)
     .on('unlink', handler)

--- a/lib/dev-server/watch/prototypeNode.js
+++ b/lib/dev-server/watch/prototypeNode.js
@@ -6,7 +6,6 @@ const { watch } = require('./utils')
 
 async function setup () {
   const watchRoot = path.join(projectDir, 'app')
-  const whatToWatch = path.join(watchRoot, '**', '*.js')
 
   const handler = (filePath) => {
     const relativePath = path.relative(watchRoot, filePath)
@@ -14,8 +13,9 @@ async function setup () {
       events.emitExternal(eventTypes.TRIGGER_KIT_RESTART)
     }
   }
-  watch(whatToWatch, {
-    allowGlobs: true
+  watch(watchRoot, {
+    recursive: true,
+    fileExtensions: ['js', 'json']
   })
     .on('add', handler)
     .on('change', handler)

--- a/lib/dev-server/watch/prototypeStyles.js
+++ b/lib/dev-server/watch/prototypeStyles.js
@@ -7,14 +7,14 @@ const { verboseLog } = require('../../utils/verboseLogger')
 
 async function setup () {
   const watchRoot = path.join(projectDir, 'app', 'assets', 'sass')
-  const whatToWatch = path.join(watchRoot, '**', '*.{scss,sass}')
 
-  const handler = (filePath) => {
+  const handler = (type, filePath) => {
     verboseLog('SASS change detected in prototype styles watcher [%s]', filePath)
     events.emitExternal(eventTypes.REGENERATE_KIT_SASS)
   }
-  watch(whatToWatch, {
-    allowGlobs: true
+  watch(watchRoot, {
+    recursive: true,
+    fileExtensions: ['scss', 'sass']
   })
     .on('add', handler)
     .on('change', handler)

--- a/lib/dev-server/watch/utils.js
+++ b/lib/dev-server/watch/utils.js
@@ -1,16 +1,32 @@
 const chokidar = require('chokidar')
-
-function watch (whatToWatch, { allowGlobs = false, registerCloseFn = () => {} } = {}) {
-  const listener = chokidar.watch(whatToWatch, {
-    ignoreInitial: true,
-    disableGlobbing: !allowGlobs
-  })
-  registerCloseFn(async () => {
-    await listener.close()
-  })
-  return listener
-}
+const path = require('node:path')
 
 module.exports = {
-  watch
+  watch: (globOrFileOrDir, { allowGlobs = false, fileExtensions = [], allFileExtensions = false, recursive = false, registerCloseFn = () => {} }) => {
+    if (allowGlobs) {
+      throw new Error('We\'re trying not to use globs.')
+    }
+
+    if (recursive && !fileExtensions?.length && !allFileExtensions) {
+      throw new Error('No file extensions provided for watching. Please provide at least one file extension.')
+    }
+
+    function isIgnored (filePath, stats) {
+      if (!stats?.isFile()) {
+        return false
+      }
+      if (allFileExtensions) {
+        return false
+      }
+      const extension = path.extname(filePath)
+      return !extension || !fileExtensions.includes(extension.split('.')[[1]])
+    }
+    return chokidar.watch(globOrFileOrDir, {
+      ignoreInitial: true,
+      ignored: isIgnored,
+      recursive
+    }).on('all', (event, path) => {
+      console.log(event, path)
+    })
+  }
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -75,63 +75,17 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.23.5",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/highlight": "^7.23.4",
-        "chalk": "^2.4.2"
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/chalk": {
-      "version": "2.4.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/color-convert": {
-      "version": "1.9.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/color-name": {
-      "version": "1.1.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@babel/code-frame/node_modules/supports-color": {
-      "version": "5.5.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/@babel/compat-data": {
@@ -341,17 +295,19 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.23.4",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.20",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -365,83 +321,26 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.23.8",
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.6.tgz",
+      "integrity": "sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.23.7",
-        "@babel/types": "^7.23.6"
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.27.6"
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight": {
-      "version": "7.23.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.22.20",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/chalk": {
-      "version": "2.4.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-convert": {
-      "version": "1.9.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-name": {
-      "version": "1.1.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@babel/highlight/node_modules/supports-color": {
-      "version": "5.5.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.23.6",
+      "version": "7.27.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.5.tgz",
+      "integrity": "sha512-OsQd175SxWkGlzbny8J3K8TnnDD0N3lrIUtB92xwyRpzaenGZhxDvxN/JgU00U3CDZNj9tPuDJ5H0WS4Nt3vKg==",
       "dev": true,
-      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.27.3"
+      },
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -613,13 +512,14 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.22.15",
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/parser": "^7.22.15",
-        "@babel/types": "^7.22.15"
+        "@babel/code-frame": "^7.27.1",
+        "@babel/parser": "^7.27.2",
+        "@babel/types": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -667,13 +567,13 @@
       "license": "MIT"
     },
     "node_modules/@babel/types": {
-      "version": "7.23.6",
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.6.tgz",
+      "integrity": "sha512-ETyHEk2VHHvl9b9jZP5IHPavHYk57EhanlRRuae9XCpb/j5bDCbPPMOBfCWhnl/7EDJz0jEMCi/RhccCE8r1+Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.23.4",
-        "@babel/helper-validator-identifier": "^7.22.20",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -770,9 +670,10 @@
       }
     },
     "node_modules/@cucumber/cucumber/node_modules/brace-expansion": {
-      "version": "2.0.1",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -2525,9 +2426,10 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -3057,8 +2959,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "license": "MIT",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -4349,8 +4252,9 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.1",
-      "license": "MIT",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -4371,7 +4275,7 @@
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
         "qs": "6.13.0",
         "range-parser": "~1.2.1",
@@ -4386,6 +4290,10 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/express-session": {
@@ -4920,9 +4828,10 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.1",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -5051,14 +4960,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-flag": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/has-property-descriptors": {
@@ -7603,8 +7504,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "license": "MIT"
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -7628,9 +7530,10 @@
       "license": "MIT"
     },
     "node_modules/picocolors": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "ISC"
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -9065,14 +8968,6 @@
       "version": "1.0.5",
       "dev": true,
       "license": "BSD-3-Clause"
-    },
-    "node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@nowprototypeit/design-system": "1.0.8",
         "body-parser": "^1.20.2",
-        "chokidar": "^3.6.0",
+        "chokidar": "^4.0.3",
         "cookie-parser": "^1.4.6",
         "cross-spawn": "^7.0.3",
         "csrf-csrf": "^3.0.8",
@@ -2780,26 +2780,17 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
+        "readdirp": "^4.0.1"
       },
       "engines": {
-        "node": ">= 8.10.0"
+        "node": ">= 14.16.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
       }
     },
     "node_modules/chownr": {
@@ -8059,14 +8050,15 @@
       }
     },
     "node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
       "engines": {
-        "node": ">=8.10.0"
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/reflect-metadata": {
@@ -8366,9 +8358,43 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/sass/node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/sass/node_modules/immutable": {
       "version": "4.0.0",
       "license": "MIT"
+    },
+    "node_modules/sass/node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
     },
     "node_modules/saxes": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@nowprototypeit/design-system": "1.0.8",
     "body-parser": "^1.20.2",
-    "chokidar": "^3.6.0",
+    "chokidar": "^4.0.3",
     "cookie-parser": "^1.4.6",
     "cross-spawn": "^7.0.3",
     "csrf-csrf": "^3.0.8",
@@ -82,6 +82,11 @@
     "proper-lockfile": "^4.1.2",
     "selenium-webdriver": "^4.16.0",
     "standard": "^17.1.0"
+  },
+  "overrides": {
+    "nunjucks": {
+      "chokidar": "^4.0.3"
+    }
   },
   "standard": {
     "ignore": [


### PR DESCRIPTION
Dependabot has been flagging an issue with Chokidar, upgrading to Chokdiar4 required some work (https://github.com/nowprototypeit/nowprototypeit/pull/62).

I actually did this work while investigating unexpected test failures and it seemed to make the tests more reliable, but I removed this work from that PR because it turned out to not make enough difference.

This PR catches up on some dependabot flags which I doubt would affect a prototype but I prefer to stay on top of them and use updated dependencies.

Locally I'm finding that the dev performance test is failing because the minimum threshold is set to `18%` improvement and I'm experiencing a `16-17.5%` improvement.  Running the same tests on the main branch I'm experiencing similar stats.  If needed I'm happy to lower the expectation.