### PR TITLE
Speeding up browser tests

### DIFF
--- a/.github/workflows/all-tests.yaml
+++ b/.github/workflows/all-tests.yaml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [18.x, 20.x, 22.x, 24.x]
         os: [linux, windows, mac]
 
     timeout-minutes: 40
@@ -82,6 +82,7 @@ jobs:
           TAKE_SCREENSHOT_AFTER_FAILURE: true
           SCREENSHOT_DIR: screenshots
           MAX_FAILURES: 1
+          REUSE_KITS: ${{ (matrix.os == 'windows' && matrix.node-version == '18.x') && 'false' || 'true' }}
 
       - name: Upload screenshots
         if: failure()

--- a/features/nothing.feature
+++ b/features/nothing.feature
@@ -4,15 +4,3 @@ Feature: Nothing
 
   Scenario: nothing
     Given I do nothing
-
-  Scenario: nothing
-    Given I do nothing
-
-  Scenario: nothing
-    Given I do nothing
-
-  Scenario: nothing
-    Given I do nothing
-
-  Scenario: nothing
-    Given I do nothing

--- a/features/nothing.feature
+++ b/features/nothing.feature
@@ -1,6 +1,18 @@
 @nothing
+@no-variant
 Feature: Nothing
 
-  @govuk-variant
+  Scenario: nothing
+    Given I do nothing
+
+  Scenario: nothing
+    Given I do nothing
+
+  Scenario: nothing
+    Given I do nothing
+
+  Scenario: nothing
+    Given I do nothing
+
   Scenario: nothing
     Given I do nothing

--- a/features/step-definitions/hooks.steps.js
+++ b/features/step-definitions/hooks.steps.js
@@ -9,7 +9,7 @@ const os = require('os')
 const { runShutdownFunctions } = require('../../lib/utils/shutdownHandlers')
 const standardTimeout = require('./utils')
 const { kitStartTimeout } = require('./setup-helpers/timeouts')
-const { getTotalKitSetupTime, getSavableKitSetupTime } = require('./setup-helpers/kit')
+const { getTotalKitSetupTime, getSavedKitSetupTime } = require('./setup-helpers/kit')
 const resultsByTag = {}
 const maxAllowableFailures = Number(process.env.MAX_FAILURES || '99999999')
 let totalFailures = 0
@@ -192,6 +192,14 @@ After(kitStartTimeout, async function (scenario) {
   }
 })
 
+function displayMsTime (timeInMillis) {
+  const rounded = Math.round(timeInMillis / 1000)
+  if (rounded < 60) {
+    return `${rounded} seconds`
+  }
+  return `${Math.round(rounded / 6) / 10} minutes`
+}
+
 AfterAll(kitStartTimeout, async function () {
   if (configuredToLogEachStep) {
     console.log('starting after all')
@@ -219,8 +227,8 @@ AfterAll(kitStartTimeout, async function () {
 
   console.log('')
   console.log('')
-  console.log('Total kit startup time', `${Math.round(getTotalKitSetupTime() / 1000)} seconds`)
-  console.log('Time that could be saved by reusing kits', `${Math.round(getSavableKitSetupTime() / 1000)} seconds`)
+  console.log('Total kit startup time', displayMsTime(getTotalKitSetupTime()))
+  console.log('Time saved by reusing kits', displayMsTime(getSavedKitSetupTime()))
   console.log('')
   console.log('')
   console.log('Starting cleanup')

--- a/features/step-definitions/setup-helpers/browser.js
+++ b/features/step-definitions/setup-helpers/browser.js
@@ -260,7 +260,7 @@ async function getBrowser (config = {}) {
           throw new Error(`Element with selector ${selector} not found`)
         }
         const className = await element.getAttribute('class')
-        return className.split(' ')
+        return className?.split(' ')
       })
     },
     getErrorDetailSummary: async (timeoutDeclaration = standardTimeout) => {


### PR DESCRIPTION
Locally I'm seeing the full browser test run come down from ~12 minutes to ~7 minutes.

On the GitHub PR test run I'm seeing the full run come down from 50 minutes to 40 minutes.

I describe the balance between speed and reliability of tests as a pendulum swing - they weren't running reliably so I prioritised reliability over speed, now that they're running reliably I'm prioritising speed while trying to maintain that reliability.  There's a process of switching priorities until settling in a sensible mid-point where there's enough speed and enough reliability for the current tests, then as more tests are added there might need to be changes.

Previously I was running up to 10 different kits at once on quite under-powered test runners, then when I tried to move over to physical test runners (therefore multiple runs on one machine) that meant that relatively low powered machines were having to run a lot of different prototypes at once causing unreliability.  The new approach is to stop the prototype at the end of the test but not to delete it, if a new test requires the same starting prototype (the same variant and NPI version) the existing prototype can be started instead of creating a new one.

I've also added a smoke test run for Node 24, the full integration & acceptance test suites run on Node 24 but the smoke tests aren't included in those runs.  Now a selection of tests run on all supported Node versions (and Node 18 as we've only just dropped support for it) and the full suite runs on the latest LTS version - Node 24.