### PR TITLE
Fixing first-time-use of in-browser editor & hosting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+ - There was a problem when using the in-browser editor, it needs enabling in the settings and when a user first enables it they should be able to use it immediately.  There was a bug which meant the prototype needed restarting before the in-browser editor would work.  This is now fixed and the in-browser editor should work immediately after enabling it.  The tests have been update to reflect both cases.
+
 ## 0.14.1
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
- - There was a problem when using the in-browser editor, it needs enabling in the settings and when a user first enables it they should be able to use it immediately.  There was a bug which meant the prototype needed restarting before the in-browser editor would work.  This is now fixed and the in-browser editor should work immediately after enabling it.  The tests have been update to reflect both cases.
+ - There was a problem when using the in-browser editor and the hosting tab, they needs enabling in the settings and the user should be able to use them immediately after updating the settings.  There was a bug which meant the prototype needed restarting before the in-browser editor and the hosting tab would work.  This is now fixed.  The tests have been updated to reflect both cases.
 
 ## 0.14.1
 

--- a/features/editing/edit-in-browser.feature
+++ b/features/editing/edit-in-browser.feature
@@ -1,11 +1,22 @@
 
 @no-variant
-@edit-in-browser-experiment-on
 @nunjucks
-@smoke
-  Feature: Edit numjucks in-browser
-    Scenario: Edit a nunjucks file
+  Feature: Edit nunjucks in-browser
+    @edit-in-browser-experiment-on
+    Scenario: Edit a nunjucks file (when enabled before starting)
       Given I create a file "app/views/basic.njk" based on the fixture file "nunjucks/basic-example.njk"
+      When I visit "/basic"
+      And I open the in-browser editor
+      Then I should see the contents of "app/views/basic.njk" in the in-browser editor
+      When I replace the contents of the in-browser editor with the fixture file "nunjucks/really-basic-page.njk"
+      And I press the save button for the in-browser editor
+      Then the file "app/views/basic.njk" should contain the same content as the fixture file "nunjucks/really-basic-page.njk"
+
+    @smoke
+    Scenario: Edit a nunjucks file (when newly enabled)
+      Given I am on the "Experiments" settings page
+      And I turn on the "editInBrowser" setting
+      And I create a file "app/views/basic.njk" based on the fixture file "nunjucks/basic-example.njk"
       When I visit "/basic"
       And I open the in-browser editor
       Then I should see the contents of "app/views/basic.njk" in the in-browser editor

--- a/features/editing/edit-in-browser.feature
+++ b/features/editing/edit-in-browser.feature
@@ -16,6 +16,7 @@
     Scenario: Edit a nunjucks file (when newly enabled)
       Given I am on the "Experiments" settings page
       And I turn on the "editInBrowser" setting
+      And I press "Save changes"
       And I create a file "app/views/basic.njk" based on the fixture file "nunjucks/basic-example.njk"
       When I visit "/basic"
       And I open the in-browser editor

--- a/features/manage-prototype/hosting.feature
+++ b/features/manage-prototype/hosting.feature
@@ -3,8 +3,8 @@ Feature: Hosting
 @no-variant
 @hosting-experiment-on
 @smoke
-Scenario: Hosting message
-  Given Hosting is enabled for this version of the kit with logged out message "This is *an example* **from the fake API**. The format was introduced in (link:https://github.com/nowprototypeit/nowprototypeit/pull/87)."
+Scenario: Hosting message (when hosting is enabled before startup)
+  Given The API has hosting enabled for this version of the kit with logged out message "This is *an example* **from the fake API**. The format was introduced in (link:https://github.com/nowprototypeit/nowprototypeit/pull/87)."
   When I visit "/manage-prototype/hosting"
   Then the page should include a paragraph that reads "This is an example from the fake API. The format was introduced in https://github.com/nowprototypeit/nowprototypeit/pull/87."
   And the page should contain bold text saying "from the fake API"
@@ -12,9 +12,23 @@ Scenario: Hosting message
   And the page should contain a link with URL and text of "https://github.com/nowprototypeit/nowprototypeit/pull/87"
 
 @no-variant
+@smoke
+Scenario: Hosting message (when hosting is enabled after startup)
+  Given The API has hosting enabled for this version of the kit with logged out message "This is *an example* **from the fake API**. The format was introduced in (link:https://github.com/nowprototypeit/nowprototypeit/pull/87)."
+  And I am on the "Experiments" settings page
+  And I turn on the "hostingEnabled" setting
+  And I press "Save changes"
+  When I visit "/manage-prototype/hosting"
+  Then the main heading should be updated to "Prototype Hosting from Now Prototype It"
+  And the page should include a paragraph that reads "This is an example from the fake API. The format was introduced in https://github.com/nowprototypeit/nowprototypeit/pull/87."
+  And the page should contain bold text saying "from the fake API"
+  And the page should contain italic text saying "an example"
+  And the page should contain a link with URL and text of "https://github.com/nowprototypeit/nowprototypeit/pull/87"
+
+@no-variant
 @hosting-experiment-on
 Scenario: Hosting page with a different message
-  Given Hosting is enabled for this version of the kit with logged out message "Basic text"
+  Given The API has hosting enabled for this version of the kit with logged out message "Basic text"
   When I visit "/manage-prototype/hosting"
   Then the page should include a paragraph that reads "Basic text"
 
@@ -38,7 +52,7 @@ Scenario: Incompatible version with a different message
   @no-variant
   @hosting-experiment-on
   Scenario: Hosting page with a different message and no prototypes
-    Given Hosting is enabled for this version of the kit with logged out message "Basic text"
+    Given The API has hosting enabled for this version of the kit with logged out message "Basic text"
     And the fake api expects a login from "nowprototypeit" with 0/0 prototypes used
     When I visit "/manage-prototype/hosting"
     And I click the button with text "Log in"
@@ -53,7 +67,7 @@ Scenario: Incompatible version with a different message
   @no-variant
   @hosting-experiment-on
   Scenario: Hosting page when the user has upload capacity
-    Given Hosting is enabled for this version of the kit with logged out message "Basic text"
+    Given The API has hosting enabled for this version of the kit with logged out message "Basic text"
     And the fake api expects a login from "nowprototypeit" with 2/3 prototypes used
     When I visit "/manage-prototype/hosting"
     And I click the button with text "Log in"

--- a/features/step-definitions/edit-in-browser.steps.js
+++ b/features/step-definitions/edit-in-browser.steps.js
@@ -3,6 +3,14 @@ const { waitForConditionToBeMet, readFixtureFile, readPrototypeFile } = require(
 const { standardTimeout, tinyTimeout } = require('./setup-helpers/timeouts')
 
 When('I open the in-browser editor', standardTimeout, async function () {
+  await waitForConditionToBeMet(standardTimeout, async () => {
+    const text = await this.browser.getTextFromSelector('#nowprototypeit-in-browser-bar_edit-button')
+    const editInBrowserExpectedText = 'Edit this page'
+    if (!text || text !== editInBrowserExpectedText) {
+      throw new Error(`Edit in browser button not found or text is incorrect - expected [${editInBrowserExpectedText}], got [${text}]`)
+    }
+    return true
+  })
   await this.browser.clickId('nowprototypeit-in-browser-bar_edit-button')
 })
 

--- a/features/step-definitions/manage-prototype.steps.js
+++ b/features/step-definitions/manage-prototype.steps.js
@@ -8,7 +8,7 @@ Given('the API contains a message for this version of the kit with text {string}
   ])
 })
 
-Given('Hosting is enabled for this version of the kit with logged out message {string}', standardTimeout, async function (message) {
+Given('The API has hosting enabled for this version of the kit with logged out message {string}', standardTimeout, async function (message) {
   await this.fakeApi.setHostingConfigForVersion(this.kit.version, true, message)
 })
 

--- a/features/step-definitions/settings.steps.js
+++ b/features/step-definitions/settings.steps.js
@@ -4,7 +4,12 @@ const { standardTimeout, mediumActionTimeout, tinyTimeout } = require('./setup-h
 
 Given('I am on the plugin settings page for the {string} plugin', standardTimeout, async function (pluginName) {
   await this.browser.openUrl('/manage-prototype/settings')
-  await this.browser.clickPluginSettingsForPluginName(pluginName)
+  await this.browser.clickPluginSettingsForPluginNameOrSettingsCategory(pluginName)
+})
+
+Given('I am on the {string} settings page', standardTimeout, async function (pluginName) {
+  await this.browser.openUrl('/manage-prototype/settings')
+  await this.browser.clickPluginSettingsForPluginNameOrSettingsCategory(pluginName)
 })
 
 When('I turn off the {string} setting', mediumActionTimeout, async function (fieldName) {

--- a/features/step-definitions/setup-helpers/browser.js
+++ b/features/step-definitions/setup-helpers/browser.js
@@ -419,7 +419,7 @@ async function getBrowser (config = {}) {
         await $submitButton.click()
       })
     },
-    clickPluginSettingsForPluginName: async (pluginName) => {
+    clickPluginSettingsForPluginNameOrSettingsCategory: async (pluginOrCategoryName) => {
       return await autoRetry(async () => {
         const $$subNavItems = await page.$$('.nowprototypeit-sub-nav-item')
         const linkInfo = await Promise.all($$subNavItems.map(async ($item) => {
@@ -436,9 +436,9 @@ async function getBrowser (config = {}) {
           }
         }))
 
-        const link = linkInfo.find(({ text }) => text === pluginName)
+        const link = linkInfo.find(({ text }) => text === pluginOrCategoryName)
         if (!link) {
-          throw new Error(`Could not find link for ${pluginName}, links were [${linkInfo.map(({ text }) => text).join(', ')}]`)
+          throw new Error(`Could not find link for ${pluginOrCategoryName}, links were [${linkInfo.map(({ text }) => text).join(', ')}]`)
         }
         await link.linkElement.click()
       })

--- a/features/step-definitions/utils.js
+++ b/features/step-definitions/utils.js
@@ -29,6 +29,10 @@ const kitAndBrowserStore = (() => {
 })()
 
 async function removeKit (kit) {
+  if (!kit) {
+    console.warn('No kit provided to removeKit, nothing to do')
+    return
+  }
   const key = kit.storageKey
   await kit.close()
   await kit.cleanup()

--- a/lib/dev-server/manage-prototype/routes/editInBrowser.js
+++ b/lib/dev-server/manage-prototype/routes/editInBrowser.js
@@ -24,6 +24,16 @@ const mapStyle = x => {
   return x.trim() === '' ? '' : `${x} !important`
 }
 
+function editInBrowserEnabled (req, res, next) {
+  if (getConfig().editInBrowser) {
+    next()
+  } else {
+    res.status(403).send({
+      error: 'Edit in browser is not enabled'
+    })
+  }
+}
+
 function replace (cssContents, position, endOfCurrentStatement, separator, replacer) {
   const currentStatement = cssContents.substring(position, endOfCurrentStatement)
   const beforeCurrentStatement = cssContents.substring(0, position)
@@ -37,9 +47,6 @@ function replace (cssContents, position, endOfCurrentStatement, separator, repla
 
 module.exports = {
   editInBrowser: (app, config) => {
-    if (!getConfig().editInBrowser) {
-      return
-    }
     app.use('/manage-prototype/assets/edit-in-browser/monaco-editor/min/vs', express.static(path.join(packageDir, 'node_modules', 'monaco-editor', 'min', 'vs')))
     app.use('/manage-prototype/assets/edit-in-browser/monaco-editor/min/vs', express.static(path.join(projectDir, 'node_modules', 'monaco-editor', 'min', 'vs')))
     app.use('/manage-prototype/assets/edit-in-browser/main-include.js', express.static(path.join(packageDir, 'lib', 'dev-server', 'manage-prototype', 'assets', 'scripts', 'edit-in-browser.js')))
@@ -66,7 +73,7 @@ module.exports = {
       res.set('content-type', 'text/css')
       res.send(cssContents)
     })
-    app.get('/manage-prototype/edit-in-browser/file-contents', async (req, res) => {
+    app.get('/manage-prototype/edit-in-browser/file-contents', [editInBrowserEnabled], async (req, res) => {
       const { relativeFilePath } = req.query
       const absolutePath = path.join(projectDir, relativeFilePath)
       try {
@@ -81,7 +88,7 @@ module.exports = {
         })
       }
     })
-    app.put('/manage-prototype/edit-in-browser/file-contents', [jsonBodyParser], async (req, res) => {
+    app.put('/manage-prototype/edit-in-browser/file-contents', [editInBrowserEnabled, jsonBodyParser], async (req, res) => {
       const { relativeFilePath } = req.query
       const { fileContents } = req.body
       const absolutePath = path.join(projectDir, relativeFilePath)

--- a/lib/dev-server/manage-prototype/routes/management-pages/hosting.js
+++ b/lib/dev-server/manage-prototype/routes/management-pages/hosting.js
@@ -114,12 +114,22 @@ function preparePrototypeListForModel (prototypeList) {
   }))
 }
 
+function hostingEnabled (req, res, next) {
+  if (getConfig().hostingEnabled) {
+    next()
+  } else {
+    res.status(403).send({
+      error: 'Edit in browser is not enabled'
+    })
+  }
+}
+
 module.exports = {
   setupHostingPages: (router, config) => {
-    router.get('/hosting/spinner.css', (req, res) => {
+    router.get('/hosting/spinner.css', [hostingEnabled], (req, res) => {
       res.sendFile(path.resolve(__dirname, '..', '..', 'assets', 'css', 'spinner.css'))
     })
-    router.get('/hosting', async (req, res) => {
+    router.get('/hosting', [hostingEnabled], async (req, res) => {
       const hostingConfig = await lookupHostingConfig()
       if (!hostingConfig.isCompatible) {
         console.log('Hosting is not compatible with this kit version', kitVersion)
@@ -181,7 +191,7 @@ module.exports = {
       }
       return 'no matching type - ' + JSON.stringify(req.body)
     }
-    router.post('/hosting/begin-login', bodyParser.urlencoded({ extended: true }), async (req, res) => {
+    router.post('/hosting/begin-login', [hostingEnabled], bodyParser.urlencoded({ extended: true }), async (req, res) => {
       const loginType = getLoginType(req)
       try {
         const url = `${getConfig().nowPrototypeItAPIBaseUrl}/v1/auth/begin`
@@ -209,7 +219,7 @@ module.exports = {
         })
       }
     })
-    router.get('/hosting/external-login', async (req, res, next) => {
+    router.get('/hosting/external-login', [hostingEnabled], async (req, res, next) => {
       const id = req.query.id
       const outputType = req.query.outputType === 'json' ? 'json' : 'html'
       const sessionInfo = await lookupSession(id)
@@ -268,7 +278,7 @@ module.exports = {
     })
     const numberOfAjaxProgressRetries = 5
     let remainingAjaxProgressRetries = numberOfAjaxProgressRetries
-    router.post('/hosting/upload-prototype', bodyParser.urlencoded({ extended: true }), async (req, res) => {
+    router.post('/hosting/upload-prototype', [hostingEnabled], bodyParser.urlencoded({ extended: true }), async (req, res) => {
       const prototypeName = req.body['prototype-name']
       remainingAjaxProgressRetries = numberOfAjaxProgressRetries
 
@@ -314,7 +324,7 @@ module.exports = {
         res.redirect(contextPath + '/hosting?error-splash=generic')
       }
     })
-    router.get('/hosting/upload-progress-ajax', async (req, res) => {
+    router.get('/hosting/upload-progress-ajax', [hostingEnabled], async (req, res) => {
       const result = await getPrototypeUploadStatus(req.query.statusId)
       if (!result) {
         remainingAjaxProgressRetries--
@@ -334,12 +344,12 @@ module.exports = {
       }
       res.send(result)
     })
-    router.get('/hosting/upload-progress', (req, res) => {
+    router.get('/hosting/upload-progress', [hostingEnabled], (req, res) => {
       res.render('hosting-upload-progress', {
         statusId: req.query.statusId
       })
     })
-    router.post('/hosting/logout', async (req, res) => {
+    router.post('/hosting/logout', [hostingEnabled], async (req, res) => {
       const sessionValidationResponse = await validateLatestSession()
       if (sessionValidationResponse) {
         const response = await standardJsonPostRequest(`${getConfig().nowPrototypeItAPIBaseUrl}${sessionValidationResponse.signOutUrl}`, {})
@@ -350,7 +360,7 @@ module.exports = {
       res.redirect(302, '/manage-prototype')
       clearSessions()
     })
-    router.get('/hosting/profile-picture', async (req, res) => {
+    router.get('/hosting/profile-picture', [hostingEnabled], async (req, res) => {
       const sessionValidationResponse = await validateLatestSession()
       if (sessionValidationResponse) {
         const url = `${getConfig().nowPrototypeItAPIBaseUrl}${sessionValidationResponse.image}`
@@ -361,7 +371,7 @@ module.exports = {
         res.status(403).send('Not logged in')
       }
     })
-    router.get('/hosting/redirect-to-logged-in-url/:type', async (req, res, next) => {
+    router.get('/hosting/redirect-to-logged-in-url/:type', [hostingEnabled], async (req, res, next) => {
       const latestSession = await getLatestSession()
       const appName = req.query.appName
       if (!latestSession) {

--- a/lib/dev-server/manage-prototype/routes/managementPages.js
+++ b/lib/dev-server/manage-prototype/routes/managementPages.js
@@ -4,7 +4,6 @@ const { setupBasicPages } = require('./management-pages/basicPages')
 const { inheritedRoutes } = require('./management-pages/inherited-manage-prototype-routes')
 const { setupPluginRoutes } = require('./management-pages/plugins')
 const { setupDesignSystemRoutes } = require('./management-pages/design-system-routes')
-const userConfig = require('../../../config')
 const { setupHostingPages } = require('./management-pages/hosting')
 
 module.exports = {
@@ -26,9 +25,7 @@ async function setupManagePrototypeRouter (config) {
   setupPluginRoutes(router)
   inheritedRoutes(router)
   setupDesignSystemRoutes(router)
-  if (userConfig.getConfig().hostingEnabled) {
-    setupHostingPages(router, config)
-  }
+  setupHostingPages(router, config)
 
   router.use((req, res) => {
     res.status(404).send('Prototype management page not found.')


### PR DESCRIPTION
There was a problem when using the in-browser editor and the hosting tab, they needs enabling in the settings and the user should be able to use them immediately after updating the settings. There was a bug which meant the prototype needed restarting before the in-browser editor and the hosting tab would work. This is now fixed.

The tests previously set these settings before starting the kit - emulating a user coming back to a kit where the in-browser editor is already enabled, new tests have been added for the behaviour just after enabling the experiment.