### PR TITLE
Updated tests for govuk frontend release

### DIFF
--- a/.github/workflows/all-tests.yaml
+++ b/.github/workflows/all-tests.yaml
@@ -9,6 +9,9 @@ jobs:
     runs-on: linux
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
       - run: npm ci
       - run: npm run lint
 
@@ -20,6 +23,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
 
       - run: npm ci
 
@@ -43,6 +49,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
 
       - run: npm ci
 
@@ -183,10 +194,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v4
         with:
           cache: 'npm'
-          node-version: 20
+          node-version: 24
 
       - run: npm install
 

--- a/__tests__/run-performance-test.js
+++ b/__tests__/run-performance-test.js
@@ -40,7 +40,7 @@ const execArgs = {
 const numberOfRuns = Number(process.argv[2]) || 20
 const numberOfDevRuns = Math.ceil(numberOfRuns / 2)
 const npiVersionToCompare = '0.11.2'
-const govukFrontendVersion = '5.9.0'
+const govukFrontendVersion = '6.1.0'
 const minimumAcceptablePercentageImprovements = {
   // Note: These are set quite low compared to what we're seeing.  The last run on GitHub actions (`ubuntu-latest`) was:
   //

--- a/features/plugins/install-and-uninstall.feature
+++ b/features/plugins/install-and-uninstall.feature
@@ -101,7 +101,7 @@ Feature: Installing and uninstalling plugins
   @govuk-variant
   @integration
   Scenario: Only provide uninstall when the version exactly matches (will fail if new common templates version is released)
-    When I view the plugin details for the "npm:@govuk-prototype-kit/common-templates:2.0.1" plugin
+    When I view the plugin details for the "npm:@govuk-prototype-kit/common-templates" plugin
     Then I should see the "Uninstall" button
     And I should not see the "Install this version" button
     And I should not see the "Install" button

--- a/features/step-definitions/settings.steps.js
+++ b/features/step-definitions/settings.steps.js
@@ -65,7 +65,7 @@ Then('the service name in the GOV.UK header should become {string} on the URL {s
   let actual = null
   await waitForConditionToBeMet(standardTimeout, async () => {
     await this.browser.openUrl(url)
-    actual = await this.browser.getTextFromSelector('.govuk-header__service-name', tinyTimeout)
+    actual = await this.browser.getTextFromSelector('.govuk-heading-xl', tinyTimeout)
 
     return actual === headerText
   }, (reject) => {

--- a/scripts/refresh-companion-kit
+++ b/scripts/refresh-companion-kit
@@ -1,5 +1,6 @@
 #!/bin/sh
 
-mkdir -p ~/projects/prototype-kits/now-prototype-it-companion &&
-rm -Rf ~/projects/prototype-kits/now-prototype-it-companion/* &&
-./bin/cli create --version=local ~/projects/prototype-kits/now-prototype-it-companion
+mkdir -p ~/projects/prototypes/now-prototype-it-companion &&
+rm -Rf ~/projects/prototypes/now-prototype-it-companion/* &&
+rm -Rf ~/projects/prototypes/now-prototype-it-companion/.tmp &&
+./bin/cli create --version=local ~/projects/prototypes/now-prototype-it-companion

--- a/scripts/refresh-companion-kit-govuk-frontend
+++ b/scripts/refresh-companion-kit-govuk-frontend
@@ -1,5 +1,6 @@
 #!/bin/sh
 
-mkdir -p ~/projects/prototype-kits/now-prototype-it-companion &&
-rm -Rf ~/projects/prototype-kits/now-prototype-it-companion/* &&
-./bin/cli create --version=local --variant="@nowprototypeit/govuk-frontend-adaptor" --variant-dependency="$(pwd)/../adaptors/govuk-frontend-adaptor" ~/projects/prototype-kits/now-prototype-it-companion
+mkdir -p ~/projects/prototypes/now-prototype-it-companion &&
+rm -Rf ~/projects/prototypes/now-prototype-it-companion/* &&
+rm -Rf ~/projects/prototypes/now-prototype-it-companion/.tmp &&
+./bin/cli create --version=local --variant="@nowprototypeit/govuk-frontend-adaptor" --variant-dependency="$(pwd)/../adaptors/govuk-frontend-adaptor" ~/projects/prototypes/now-prototype-it-companion

--- a/scripts/refresh-companion-kit-lma
+++ b/scripts/refresh-companion-kit-lma
@@ -1,5 +1,6 @@
 #!/bin/sh
 
-mkdir -p ~/projects/prototype-kits/now-prototype-it-companion &&
-rm -Rf ~/projects/prototype-kits/now-prototype-it-companion/* &&
-./bin/cli create --version=local --variant="louisa-may-alcott" --variant-dependency="$(pwd)/features/fixtures/plugins/louisa-may-alcott" ~/projects/prototype-kits/now-prototype-it-companion
+mkdir -p ~/projects/prototypes/now-prototype-it-companion &&
+rm -Rf ~/projects/prototypes/now-prototype-it-companion/* &&
+rm -Rf ~/projects/prototypes/now-prototype-it-companion/.tmp &&
+./bin/cli create --version=local --variant="louisa-may-alcott" --variant-dependency="$(pwd)/features/fixtures/plugins/louisa-may-alcott" ~/projects/prototypes/now-prototype-it-companion

--- a/scripts/refresh-companion-kit-mpj
+++ b/scripts/refresh-companion-kit-mpj
@@ -1,5 +1,6 @@
 #!/bin/sh
 
-mkdir -p ~/projects/prototype-kits/now-prototype-it-companion &&
-rm -Rf ~/projects/prototype-kits/now-prototype-it-companion/* &&
-./bin/cli create --version=local --variant="marsha-p-johnson" --variant-dependency="$(pwd)/features/fixtures/plugins/marsha-p-johnson" ~/projects/prototype-kits/now-prototype-it-companion
+mkdir -p ~/projects/prototypes/now-prototype-it-companion &&
+rm -Rf ~/projects/prototypes/now-prototype-it-companion/* &&
+rm -Rf ~/projects/prototypes/now-prototype-it-companion/.tmp &&
+./bin/cli create --version=local --variant="marsha-p-johnson" --variant-dependency="$(pwd)/features/fixtures/plugins/marsha-p-johnson" ~/projects/prototypes/now-prototype-it-companion


### PR DESCRIPTION
There were two failing tests, both were correctly identified as integration tests meaning that they may fail if something external changes.

I've also rolled in a change I've been sitting on for a while - renaming `~/projects/prototype-kits` to `~/projects/prototypes` as it's more accurate terminology.